### PR TITLE
CI: update GH-actions flow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,52 +6,68 @@ on:
 
 jobs:
 
+  build-binaries:
+    runs-on: ubuntu-latest
+    env:
+      CC: gcc-9
+      CXX: g++-9
+
+    steps:
+
+    - name: Install dependencies
+      run: |
+        sudo apt-get update -qq
+        sudo apt install -y g++-9 build-essential cmake tclsh ant default-jre swig google-perftools libgoogle-perftools-dev python3 python3-dev uuid uuid-dev tcl-dev flex libfl-dev
+
+    - uses: actions/checkout@v2
+      with:
+        submodules: recursive
+        fetch-depth: 0
+
+    - uses: actions/setup-python@v2
+      with:
+         python-version: '3.x'
+
+    - name: Build binaries
+      run: |
+        make -j$(nproc) prep
+        mkdir -p output
+        mv image output/
+
+    - name: Upload binaries
+      uses: actions/upload-artifact@v2
+      with:
+        name: binaries
+        path: output
+
+  generate-matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.generate.outputs.matrix }}
+    steps:
+      - name: Checkout master
+        uses: actions/checkout@v2
+
+      - uses: actions/setup-python@v2
+        with:
+           python-version: '3.x'
+
+      - name: Generate matrix
+        id: generate
+        run: |
+          matrix="$(python list.py -d tests -s ibex yosys synthesis)"
+          echo "::set-output name=matrix::$matrix"
+          echo "Matrix: $matrix"
 
   tests:
     runs-on: ubuntu-latest
+    needs: [build-binaries, generate-matrix]
     strategy:
       matrix:
-        TEST_CASE:
-          - onenet
-          - OneNetModport
-          - OneFF
-          - OneAnd
-          - OneDivider
-          - OneNetInterf
-          - OneNetRange
-          - OneConcat
-          - OneReplicate
-          - OneAlwaysComb
-          - OneShift
-          - OneArithShift
-          - OneSysFunc
-          - OneInside
-          - OneImport
-          - OneCast
-          - OnePackage
-          - OneStruct
-          - fsm_single_always
-          - fsm_using_function
-          - fsm_using_always
-          - AluOps
-          - UnitForLoop
-          - GenerateAssigns
-          - AssignmentPattern
-          - MixedPatterns
-          - MultipleCells
-          - MultipleNets
-          - MultiplePrints
-          - IndexedPartSelect
-          - PartSelect
-          - VarSelect
-          - EnumInPackage
-          - StructInPackage
+        TEST_CASE: ${{ fromJson(needs.generate-matrix.outputs.matrix) }}
         TARGET:
           - uhdm/yosys/test-ast
           - uhdm/verilator/test-ast
-        exclude:
-          - TEST_CASE: OneThis
-            TARGET: uhdm/verilator/test-ast
       fail-fast:
         false
     env:
@@ -74,15 +90,26 @@ jobs:
       with:
          python-version: '3.x'
 
+    - name: Download binaries
+      uses: actions/download-artifact@v2
+      with:
+        name: binaries
+
+    - name: Update binaries timestamp
+      run: |
+        cd image
+        find . -type f -exec touch {} +
+
     - name: Build & Test
       run: ./.github/ci.sh
       env:
-        TEST_CASE: tests/${{ matrix.TEST_CASE }}
+        TEST_CASE: ${{ matrix.TEST_CASE }}
         TARGET: ${{ matrix.TARGET }}
 
 
   surelog-uhdm:
     runs-on: ubuntu-latest
+    needs: build-binaries
     env:
       CC: gcc-9
       CXX: g++-9
@@ -103,6 +130,16 @@ jobs:
       with:
          python-version: '3.x'
 
+    - name: Download binaries
+      uses: actions/download-artifact@v2
+      with:
+        name: binaries
+
+    - name: Update binaries timestamp
+      run: |
+        cd image
+        find . -type f -exec touch {} +
+
     - name: Build & Test
       run: ./.github/ci.sh
       env:
@@ -111,6 +148,7 @@ jobs:
 
   ibex_synth:
     runs-on: ubuntu-latest
+    needs: build-binaries
     strategy:
       matrix:
         TARGET: [uhdm/yosys/synth-ibex]
@@ -135,6 +173,16 @@ jobs:
     - uses: actions/setup-python@v2
       with:
          python-version: '3.7'
+
+    - name: Download binaries
+      uses: actions/download-artifact@v2
+      with:
+        name: binaries
+
+    - name: Update binaries timestamp
+      run: |
+        cd image
+        find . -type f -exec touch {} +
 
     - name: Build & Test
       run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,19 +26,21 @@ jobs:
 
     - uses: actions/setup-python@v2
       with:
-         python-version: '3.x'
+         python-version: '3.7'
 
     - name: Build binaries
       run: |
         make -j$(nproc) prep
-        mkdir -p output
-        mv image output/
+        # By default actions/upload-artifact@v2 do not preserve file permissions
+        # tar directory to workaround this issue
+        # See https://github.com/actions/upload-artifact/issues/38
+        tar -cvf binaries.tar image
 
     - name: Upload binaries
       uses: actions/upload-artifact@v2
       with:
         name: binaries
-        path: output
+        path: binaries.tar
 
   generate-matrix:
     runs-on: ubuntu-latest
@@ -50,7 +52,7 @@ jobs:
 
       - uses: actions/setup-python@v2
         with:
-           python-version: '3.x'
+           python-version: '3.7'
 
       - name: Generate matrix
         id: generate
@@ -68,6 +70,7 @@ jobs:
         TARGET:
           - uhdm/yosys/test-ast
           - uhdm/verilator/test-ast
+          - uhdm/vcddiff
       fail-fast:
         false
     env:
@@ -88,12 +91,16 @@ jobs:
 
     - uses: actions/setup-python@v2
       with:
-         python-version: '3.x'
+         python-version: '3.7'
 
     - name: Download binaries
       uses: actions/download-artifact@v2
       with:
         name: binaries
+
+    # See https://github.com/actions/upload-artifact/issues/38
+    - name: Extract
+      run: tar -xf binaries.tar
 
     - name: Update binaries timestamp
       run: |
@@ -128,12 +135,16 @@ jobs:
 
     - uses: actions/setup-python@v2
       with:
-         python-version: '3.x'
+         python-version: '3.7'
 
     - name: Download binaries
       uses: actions/download-artifact@v2
       with:
         name: binaries
+
+    # See https://github.com/actions/upload-artifact/issues/38
+    - name: Extract
+      run: tar -xf binaries.tar
 
     - name: Update binaries timestamp
       run: |
@@ -178,6 +189,10 @@ jobs:
       uses: actions/download-artifact@v2
       with:
         name: binaries
+
+    # See https://github.com/actions/upload-artifact/issues/38
+    - name: Extract
+      run: tar -xf binaries.tar
 
     - name: Update binaries timestamp
       run: |

--- a/Makefile
+++ b/Makefile
@@ -4,164 +4,144 @@ TEST ?= tests/onenet
 root_dir:=$(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
 SURELOG_BIN = ${root_dir}/image/bin/surelog
-YOSYS_BIN = ${root_dir}/yosys/yosys
-VERILATOR = ${root_dir}/image/bin/verilator
+YOSYS_BIN = ${root_dir}/image/bin/yosys
+VERILATOR_BIN = ${root_dir}/image/bin/verilator
+VCDDIFF_BIN = ${root_dir}/image/bin/vcddiff
 COVARAGE_REPORT = ${root_dir}/build/coverage
 TOP_UHDM = ${root_dir}/build/top.uhdm
 
+TEST_DIR := $(root_dir)/$(TEST)
+MAIN_FILE := $(TEST_DIR)/main.cpp
+YOSYS_SCRIPT := $(TEST_DIR)/yosys_script
+
+# this include should set $(TOP_FILE) and $(TOP_MODULE) variables
 include $(TEST)/Makefile.in
+
+# this variables uses $(TOP_MODULE) that is set in included Makefile.in
+VERILATED_BIN := Vwork_$(TOP_MODULE)
+TOP_MAKEFILE := $(VERILATED_BIN).mk
 
 list:
 	@echo "Available tests:"
 	@for TEST in $(TESTS); do echo "- tests/$$TEST"; done
 	@echo "Please specify the TEST variable."
 
-verilator/configure: verilator/configure.ac
-	(cd verilator && autoconf)
+# ------------ Binaries build targets ------------
 
-verilator/Makefile: verilator/configure
-	(cd verilator && ./configure --prefix=$(PWD)/image)
-
-verilator/bin/verilator_bin: verilator/Makefile uhdm/build
-	$(MAKE) -C verilator
-
-image/bin/verilator: verilator/bin/verilator_bin
-	$(MAKE) -C verilator install
-
-yosys/yosys: yosys/Makefile uhdm/build
-	(cd yosys && \
-		$(MAKE))
-
-prep: image/bin/verilator yosys/yosys
-
-clean::
-	rm -rf build
-
-vcd:
-	gtkwave build/dump.vcd &>/dev/null &
-
-build-verilator:
-	(cd verilator/src && make ../bin/verilator_bin)
-
-veri: build-verilator image/bin/verilator
-
-vcddiff/vcddiff:
-	$(MAKE) -C vcddiff
-
-# ------------ Surelog ------------
 Surelog/third_party/UHDM/.gitpatch: ${root_dir}/UHDM.patch
-	(cd Surelog/third_party/UHDM && git apply ${root_dir}/UHDM.patch) && touch $@
+	(cd ${root_dir}/Surelog/third_party/UHDM && git apply ${root_dir}/UHDM.patch) && touch $@
 
-surelog: Surelog/third_party/UHDM/.gitpatch
-	(cd Surelog && \
+image/bin/verilator: verilator/configure.ac image/bin/surelog
+	(cd ${root_dir}/verilator && autoconf && ./configure --prefix=$(root_dir)/image && \
+		$(MAKE) install)
+
+image/bin/yosys: yosys/Makefile image/bin/surelog
+	(cd ${root_dir}/yosys && $(MAKE) PREFIX=$(root_dir)/image install)
+
+image/bin/surelog: Surelog/third_party/UHDM/.gitpatch
+	(cd ${root_dir}/Surelog && \
 		$(MAKE) PREFIX=${root_dir}/image release install)
 
-surelog/regression: surelog
-	(cd Surelog && \
-		$(MAKE) regression)
+image/bin/vcddiff:
+	$(MAKE) -C vcddiff PREFIX=$(root_dir)/image
+	mkdir -p $(root_dir)/image/bin
+	cp -p vcddiff/vcddiff $(VCDDIFF_BIN)
 
-surelog/parse: surelog
-	mkdir -p ${root_dir}/build
+prep: image/bin/verilator image/bin/yosys image/bin/surelog image/bin/vcddiff
+
+# ------------ Test targets ------------
+
+uhdm/vcddiff: image/bin/vcddiff uhdm/verilator/test-ast uhdm/yosys/verilate-ast
+	$(VCDDIFF_BIN) $(root_dir)/build/dump_yosys.vcd $(root_dir)/build/dump_verilator.vcd
+
+uhdm/verilator/test-ast: image/bin/verilator surelog/parse
+	(cd $(root_dir)/build && \
+		$(VERILATOR_BIN) --uhdm-ast --cc $(TOP_UHDM) \
+			--top-module work_$(TOP_MODULE) \
+			--dump-uhdm \
+			--exe $(MAIN_FILE) --trace && \
+		 make -j -C obj_dir -f $(TOP_MAKEFILE) $(VERILATED_BIN) && \
+		 obj_dir/$(VERILATED_BIN))
+	cp $(root_dir)/build/dump.vcd $(root_dir)/build/dump_verilator.vcd
+
+uhdm/yosys/test-ast: image/bin/yosys surelog/parse clean-build
+	(cd $(root_dir)/build && ${YOSYS_BIN} -s $(YOSYS_SCRIPT))
+
+# ------------ Test helper targets ------------
+
+surelog/parse: image/bin/surelog clean-build
 	(cd ${root_dir}/build && \
-		${SURELOG_BIN} -parse -sverilog -d coveruhdm ../$(TOP_FILE))
+		${SURELOG_BIN} -parse -sverilog -d coveruhdm $(TOP_FILE))
 	cp ${root_dir}/build/slpp_all/surelog.uhdm ${root_dir}/build/top.uhdm
 
-surelog/parse-earlgrey: surelog
-	mkdir -p ${root_dir}/build
-	(cd ${root_dir}/Surelog/third_party/tests/Earlgrey_0_1/sim-icarus && \
-		${SURELOG_BIN} -f Earlgrey_0_1.sl \
-	)
-	cp ${root_dir}/Surelog/third_party/tests/Earlgrey_0_1/sim-icarus/slpp_all/surelog.uhdm ${root_dir}/build/top.uhdm
+uhdm/yosys/verilate-ast: uhdm/yosys/test-ast image/bin/verilator
+	(cd $(root_dir)/build && \
+		$(VERILATOR_BIN) --cc ./yosys.sv \
+			--top-module \$(TOP_MODULE) \
+			--exe $(MAIN_FILE) --trace && \
+		 make -j -C obj_dir -f $(TOP_MAKEFILE) $(VERILATED_BIN) && \
+		 obj_dir/$(VERILATED_BIN))
+	cp $(root_dir)/build/dump.vcd $(root_dir)/build/dump_yosys.vcd
 
-surelog/ibex-verilator: surelog
-	mkdir -p ${root_dir}/build
-	-(cd ${root_dir}/Surelog/third_party/tests/Earlgrey_Verilator_0_1/sim-verilator && \
-		${SURELOG_BIN} -f Earlgrey_Verilator_0_1.sl \
-	)
-	cp ${root_dir}/Surelog/third_party/tests/Earlgrey_Verilator_0_1/sim-verilator/slpp_all/surelog.uhdm ${root_dir}/build/top.uhdm
+# ------------ Coverage targets ------------
 
-surelog/ibex-simplesystem: surelog
-	mkdir -p ${root_dir}/build
-	(cd ${root_dir}/tests/ibex/ibex/build/lowrisc_ibex_ibex_simple_system_0/sim-verilator \
-		${SURELOG_BIN} +define+VERILATOR \
-			-f lowrisc_ibex_ibex_simple_system_0.vc \
-			-parse -d coveruhdm -verbose \
-	)
-	cp ${root_dir}/tests/ibex/ibex/build/lowrisc_ibex_ibex_simple_system_0/sim-verilator/slpp_all/surelog.uhdm ${root_dir}/build/top.uhdm
-# ------------ UHDM ------------ 
+uhdm/verilator/coverage: image/bin/verilator surelog/parse
+	(cd $(root_dir)/build && \
+		$(VERILATOR_BIN) --uhdm-ast --cc $(TOP_UHDM) \
+			--uhdm-cov uhdm.cov \
+			--xml-only)
+	python3 gen_coverage_report.py --verilator-uhdm $(root_dir)/build/uhdm.cov \
+		--output-file $(root_dir)/build/coverage.out
 
-uhdm/clean:
-	rm -rf obj_dir slpp_all build
+uhdm/yosys/coverage: image/bin/yosys surelog/parse
+	(cd ${root_dir}/build && ${YOSYS_BIN} -p "read_uhdm -report ${COVARAGE_REPORT} ${TOP_UHDM}")
 
-uhdm/cleanall: uhdm/clean
-	rm -rf ./image
+# ------------ Clean targets ------------
+
+clean-build:
+	rm -rf $(root_dir)/build
+	mkdir -p $(root_dir)/build
+
+clean: clean-build
+	rm -rf $(root_dir)/image
+
+cleanall: clean
 	$(MAKE) -C verilator clean
 	$(MAKE) -C Surelog clean
 	$(MAKE) -C yosys clean
 	$(MAKE) -C vcddiff clean
 
-uhdm/build: Surelog/third_party/UHDM/.gitpatch
-	mkdir -p ${root_dir}/Surelog/third_party/UHDM/build
-	(cd ${root_dir}/Surelog/third_party/UHDM && cmake \
-		-DCMAKE_INSTALL_PREFIX=$(root_dir)/image \
-		-DCMAKE_BUILD_TYPE=Release \
-		-S . \
-		-B build && cmake --build build && \
-	 $(MAKE) install)
+# ------------ Other targets ------------
 
-uhdm/verilator/build: uhdm/build image/bin/verilator
+surelog/parse-earlgrey: image/bin/surelog clean-build
+	(cd ${root_dir}/Surelog/third_party/tests/Earlgrey_0_1/sim-icarus && \
+		${SURELOG_BIN} -f Earlgrey_0_1.sl \
+	)
+	cp ${root_dir}/Surelog/third_party/tests/Earlgrey_0_1/sim-icarus/slpp_all/surelog.uhdm ${root_dir}/build/top.uhdm
 
-uhdm/verilator/get-ast: uhdm/verilator/build
-	mkdir -p build
-	(cd build && \
-		../image/bin/verilator --cc ../$(TOP_FILE) \
-			--exe ../$(MAIN_FILE) --debug --xml-only)
+surelog/ibex-verilator: image/bin/surelog clean-build
+	(cd ${root_dir}/Surelog/third_party/tests/Earlgrey_Verilator_0_1/sim-verilator && \
+		${SURELOG_BIN} -f Earlgrey_Verilator_0_1.sl)
+	cp ${root_dir}/Surelog/third_party/tests/Earlgrey_Verilator_0_1/sim-verilator/slpp_all/surelog.uhdm ${root_dir}/build/top.uhdm
 
-uhdm/verilator/ast-xml: uhdm/verilator/build surelog/parse
-	mkdir -p build
-	(cd build && \
-		../image/bin/verilator --uhdm-ast --cc ./top.uhdm \
+surelog/ibex-simplesystem: image/bin/surelog clean-build
+	(cd ${root_dir}/tests/ibex/ibex/build/lowrisc_ibex_ibex_simple_system_0/sim-verilator \
+		${SURELOG_BIN} +define+VERILATOR \
+			-f lowrisc_ibex_ibex_simple_system_0.vc \
+			-parse -d coveruhdm -verbose)
+	cp ${root_dir}/tests/ibex/ibex/build/lowrisc_ibex_ibex_simple_system_0/sim-verilator/slpp_all/surelog.uhdm ${root_dir}/build/top.uhdm
+
+uhdm/verilator/get-ast: image/bin/verilator clean-build
+	(cd $(root_dir)/build && \
+		$(VERILATOR_BIN) --cc $(TOP_FILE) \
+			--exe $(MAIN_FILE) --debug --xml-only)
+
+uhdm/verilator/ast-xml: image/bin/verilator surelog/parse
+	(cd $(root_dir)/build && \
+		$(VERILATOR_BIN) --uhdm-ast --cc ./top.uhdm \
 			--top-module work_$(TOP_MODULE) \
 			--dump-uhdm \
-			--exe ../$(MAIN_FILE) --xml-only --debug)
+			--exe $(MAIN_FILE) --xml-only --debug)
 
-uhdm/verilator/test-ast: uhdm/verilator/build surelog/parse
-	mkdir -p build
-	(cd build && \
-		../image/bin/verilator --uhdm-ast --cc ./top.uhdm \
-			--top-module work_$(TOP_MODULE) \
-			--dump-uhdm \
-			--exe ../$(MAIN_FILE) --trace && \
-		 make -j -C obj_dir -f $(TOP_MAKEFILE) $(VERILATED_BIN) && \
-		 obj_dir/$(VERILATED_BIN))
-
-uhdm/verilator/coverage: uhdm/verilator/build
-	mkdir -p build
-	-(cd build && \
-		../image/bin/verilator --uhdm-ast --cc ./top.uhdm \
-			--uhdm-cov uhdm.cov \
-			--xml-only)
-	python3 gen_coverage_report.py --verilator-uhdm build/uhdm.cov \
-		--output-file build/coverage.out
-
-uhdm/yosys/test-ast: yosys/yosys surelog/parse
-	mkdir -p build
-	(cd build && \
-		${YOSYS_BIN} -s ../$(YOSYS_SCRIPT))
-
-uhdm/yosys/verilate-ast: uhdm/yosys/test-ast uhdm/verilator/build
-	(cd build && \
-		../image/bin/verilator --cc ./yosys.sv \
-			--top-module \$(TOP_MODULE) \
-			--exe ../$(MAIN_FILE) --trace && \
-		 make -j -C obj_dir -f $(TOP_MAKEFILE) $(VERILATED_BIN) && \
-		 obj_dir/$(VERILATED_BIN))
-
-
-uhdm/vcddiff: vcddiff/vcddiff
-	$(MAKE) uhdm/verilator/test-ast
-	mv build/dump.vcd build/dump_verilator.vcd
-	rm -rf build/obj_dir
-	$(MAKE) uhdm/yosys/verilate-ast
-	mv build/dump.vcd build/dump_yosys.vcd
-	vcddiff/vcddiff build/dump_yosys.vcd build/dump_verilator.vcd
+vcd:
+	gtkwave $(root_dir)/build/dump.vcd &>/dev/null &

--- a/list.py
+++ b/list.py
@@ -1,0 +1,20 @@
+#!/usr/bin/python
+
+import argparse
+import json
+import os
+import os.path
+import sys
+
+parser = argparse.ArgumentParser()
+parser.add_argument('--directory', '-d', type=str,
+                    help='generate list from the specifiec directory')
+
+parser.add_argument('--skip-elements', '-s',
+                    nargs='*', default=[],
+                    help='list of elements to skip')
+
+args = parser.parse_args()
+
+# skip ibex test as it is handled separately
+print(json.dumps([f"tests/{node}" for node in os.listdir(args.directory) if node not in args.skip_elements]))

--- a/tests/AluOps/Makefile.in
+++ b/tests/AluOps/Makefile.in
@@ -1,6 +1,2 @@
-TOP_FILE := tests/AluOps/dut.v
-MAIN_FILE := tests/AluOps/main.cpp
-YOSYS_SCRIPT := tests/AluOps/yosys_script
+TOP_FILE := $(TEST_DIR)/dut.v
 TOP_MODULE := dut
-VERILATED_BIN := Vwork_$(TOP_MODULE)
-TOP_MAKEFILE := $(VERILATED_BIN).mk

--- a/tests/AssignmentPattern/Makefile.in
+++ b/tests/AssignmentPattern/Makefile.in
@@ -1,6 +1,2 @@
-TOP_FILE := tests/AssignmentPattern/top.sv
-MAIN_FILE := tests/AssignmentPattern/main.cpp
-YOSYS_SCRIPT := tests/AssignmentPattern/yosys_script
+TOP_FILE := $(TEST_DIR)/top.sv
 TOP_MODULE := top
-VERILATED_BIN := Vwork_$(TOP_MODULE)
-TOP_MAKEFILE := $(VERILATED_BIN).mk

--- a/tests/EnumInPackage/Makefile.in
+++ b/tests/EnumInPackage/Makefile.in
@@ -1,6 +1,2 @@
-TOP_FILE := tests/EnumInPackage/dut.sv
-MAIN_FILE := tests/EnumInPackage/main.cpp
-YOSYS_SCRIPT := tests/EnumInPackage/yosys_script
+TOP_FILE := $(TEST_DIR)/dut.sv
 TOP_MODULE := dut
-VERILATED_BIN := Vwork_$(TOP_MODULE)
-TOP_MAKEFILE := $(VERILATED_BIN).mk

--- a/tests/EnumInPackage/dut.sv
+++ b/tests/EnumInPackage/dut.sv
@@ -19,7 +19,7 @@ package pkg3;
     } enum2;
 endpackage
 
-module dut;  
+module dut(var1, var2, var3, var4);
     typedef enum logic[7:0] {
         SEVENTH = 8'b01011010,
         EIGHTH  = 8'b11010011
@@ -27,10 +27,10 @@ module dut;
 
    import pkg3::*;
 
-    pkg1::enum1 var1;
-    pkg2::enum1 var2;
-    enum2 var3;
-    enum3 var4;
+    output pkg1::enum1 var1;
+    output pkg2::enum1 var2;
+    output enum2 var3;
+    output enum3 var4;
 
     assign var1 = pkg1::FIRST;
     assign var2 = pkg2::FOURTH;

--- a/tests/FSMBsp13/Makefile.in
+++ b/tests/FSMBsp13/Makefile.in
@@ -1,6 +1,2 @@
-TOP_FILE := Surelog/tests/FSMBsp13/dut.v
-MAIN_FILE := tests/FSMBsp13/main.cpp
-YOSYS_SCRIPT := tests/FSMBsp13/yosys_script
+TOP_FILE := $(root_dir)/Surelog/$(TEST)/dut.v
 TOP_MODULE := dut
-VERILATED_BIN := Vwork_$(TOP_MODULE)
-TOP_MAKEFILE := $(VERILATED_BIN).mk

--- a/tests/GenerateAssigns/Makefile.in
+++ b/tests/GenerateAssigns/Makefile.in
@@ -1,6 +1,2 @@
-TOP_FILE := Surelog/tests/GenerateAssigns/top.v
-MAIN_FILE := tests/GenerateAssigns/main.cpp
-YOSYS_SCRIPT := tests/GenerateAssigns/yosys_script
+TOP_FILE := $(root_dir)/Surelog/tests/GenerateAssigns/top.v
 TOP_MODULE := dut
-VERILATED_BIN := Vwork_$(TOP_MODULE)
-TOP_MAKEFILE := $(VERILATED_BIN).mk

--- a/tests/IndexedPartSelect/Makefile.in
+++ b/tests/IndexedPartSelect/Makefile.in
@@ -1,6 +1,2 @@
-TOP_FILE := tests/IndexedPartSelect/top.sv
-MAIN_FILE := tests/IndexedPartSelect/main.cpp
-YOSYS_SCRIPT := tests/IndexedPartSelect/yosys_script
+TOP_FILE := $(TEST_DIR)/top.sv
 TOP_MODULE := top
-VERILATED_BIN := Vwork_$(TOP_MODULE)
-TOP_MAKEFILE := $(VERILATED_BIN).mk

--- a/tests/MixedPatterns/Makefile.in
+++ b/tests/MixedPatterns/Makefile.in
@@ -1,6 +1,2 @@
-TOP_FILE := tests/MixedPatterns/top.sv
-MAIN_FILE := tests/MixedPatterns/main.cpp
-YOSYS_SCRIPT := tests/MixedPatterns/yosys_script
+TOP_FILE := $(TEST_DIR)/top.sv
 TOP_MODULE := top
-VERILATED_BIN := Vwork_$(TOP_MODULE)
-TOP_MAKEFILE := $(VERILATED_BIN).mk

--- a/tests/MultipleCells/Makefile.in
+++ b/tests/MultipleCells/Makefile.in
@@ -1,6 +1,2 @@
-TOP_FILE := tests/MultipleCells/top.sv
-MAIN_FILE := tests/MultipleCells/main.cpp
-YOSYS_SCRIPT := tests/MultipleCells/yosys_script
+TOP_FILE := $(TEST_DIR)/top.sv
 TOP_MODULE := top
-VERILATED_BIN := Vwork_$(TOP_MODULE)
-TOP_MAKEFILE := $(VERILATED_BIN).mk

--- a/tests/MultipleNets/Makefile.in
+++ b/tests/MultipleNets/Makefile.in
@@ -1,6 +1,2 @@
-TOP_FILE := tests/MultipleNets/top.sv
-MAIN_FILE := tests/MultipleNets/main.cpp
-YOSYS_SCRIPT := tests/MultipleNets/yosys_script
+TOP_FILE := $(TEST_DIR)/top.sv
 TOP_MODULE := top
-VERILATED_BIN := Vwork_$(TOP_MODULE)
-TOP_MAKEFILE := $(VERILATED_BIN).mk

--- a/tests/MultiplePrints/Makefile.in
+++ b/tests/MultiplePrints/Makefile.in
@@ -1,6 +1,2 @@
-TOP_FILE := tests/MultiplePrints/top.sv
-MAIN_FILE := tests/MultiplePrints/main.cpp
-YOSYS_SCRIPT := tests/MultiplePrints/yosys_script
+TOP_FILE := $(TEST_DIR)/top.sv
 TOP_MODULE := top
-VERILATED_BIN := Vwork_$(TOP_MODULE)
-TOP_MAKEFILE := $(VERILATED_BIN).mk

--- a/tests/OneAlwaysComb/Makefile.in
+++ b/tests/OneAlwaysComb/Makefile.in
@@ -1,6 +1,2 @@
-TOP_FILE := tests/OneAlwaysComb/dut.v
-MAIN_FILE := tests/OneAlwaysComb/main.cpp
-YOSYS_SCRIPT := tests/OneAlwaysComb/yosys_script
+TOP_FILE := $(TEST_DIR)/dut.v
 TOP_MODULE := dut
-VERILATED_BIN := Vwork_$(TOP_MODULE)
-TOP_MAKEFILE := $(VERILATED_BIN).mk

--- a/tests/OneAnd/Makefile.in
+++ b/tests/OneAnd/Makefile.in
@@ -1,6 +1,2 @@
-TOP_FILE := Surelog/tests/OneAnd/dut.v
-MAIN_FILE := tests/OneAnd/main.cpp
-YOSYS_SCRIPT := tests/OneAnd/yosys_script
+TOP_FILE := $(root_dir)/Surelog/tests/OneAnd/dut.v
 TOP_MODULE := dut
-VERILATED_BIN := Vwork_$(TOP_MODULE)
-TOP_MAKEFILE := $(VERILATED_BIN).mk

--- a/tests/OneArithShift/Makefile.in
+++ b/tests/OneArithShift/Makefile.in
@@ -1,6 +1,2 @@
-TOP_FILE := tests/OneArithShift/dut.v
-MAIN_FILE := tests/OneArithShift/main.cpp
-YOSYS_SCRIPT := tests/OneArithShift/yosys_script
+TOP_FILE := $(TEST_DIR)/dut.v
 TOP_MODULE := dut
-VERILATED_BIN := Vwork_$(TOP_MODULE)
-TOP_MAKEFILE := $(VERILATED_BIN).mk

--- a/tests/OneCast/Makefile.in
+++ b/tests/OneCast/Makefile.in
@@ -1,6 +1,2 @@
-TOP_FILE := tests/OneCast/dut.v
-MAIN_FILE := tests/OneCast/main.cpp
-YOSYS_SCRIPT := tests/OneCast/yosys_script
+TOP_FILE := $(TEST_DIR)/dut.v
 TOP_MODULE := dut
-VERILATED_BIN := Vwork_$(TOP_MODULE)
-TOP_MAKEFILE := $(VERILATED_BIN).mk

--- a/tests/OneConcat/Makefile.in
+++ b/tests/OneConcat/Makefile.in
@@ -1,6 +1,2 @@
-TOP_FILE := tests/OneConcat/dut.v
-MAIN_FILE := tests/OneConcat/main.cpp
-YOSYS_SCRIPT := tests/OneConcat/yosys_script
+TOP_FILE := $(TEST_DIR)/dut.v
 TOP_MODULE := dut
-VERILATED_BIN := Vwork_$(TOP_MODULE)
-TOP_MAKEFILE := $(VERILATED_BIN).mk

--- a/tests/OneDivider/Makefile.in
+++ b/tests/OneDivider/Makefile.in
@@ -1,6 +1,2 @@
-TOP_FILE := Surelog/tests/OneDivider/dut.v
-MAIN_FILE := tests/OneDivider/main.cpp
-YOSYS_SCRIPT := tests/OneDivider/yosys_script
+TOP_FILE := $(root_dir)/Surelog/tests/OneDivider/dut.v
 TOP_MODULE := dut
-VERILATED_BIN := Vwork_$(TOP_MODULE)
-TOP_MAKEFILE := $(VERILATED_BIN).mk

--- a/tests/OneFF/Makefile.in
+++ b/tests/OneFF/Makefile.in
@@ -1,6 +1,2 @@
-TOP_FILE := Surelog/tests/OneFF/dut.v
-MAIN_FILE := tests/OneFF/main.cpp
-YOSYS_SCRIPT := tests/OneFF/yosys_script
+TOP_FILE := $(root_dir)/Surelog/$(TEST)/dut.v
 TOP_MODULE := dut
-VERILATED_BIN := Vwork_$(TOP_MODULE)
-TOP_MAKEFILE := $(VERILATED_BIN).mk

--- a/tests/OneImport/Makefile.in
+++ b/tests/OneImport/Makefile.in
@@ -1,8 +1,2 @@
-# A hack to get two files working without touching main makefile
-# Verilator needs pkg.sv to be parsed first
-TOP_FILE := tests/OneImport/pkg.sv ../tests/OneImport/dut.sv
-MAIN_FILE := tests/OneImport/main.cpp
-YOSYS_SCRIPT := tests/OneImport/yosys_script
+TOP_FILE := $(TEST_DIR)/pkg.sv $(TEST_DIR)/dut.sv
 TOP_MODULE := dut
-VERILATED_BIN := Vwork_$(TOP_MODULE)
-TOP_MAKEFILE := $(VERILATED_BIN).mk

--- a/tests/OneInside/Makefile.in
+++ b/tests/OneInside/Makefile.in
@@ -1,6 +1,2 @@
-TOP_FILE := tests/OneInside/dut.v
-MAIN_FILE := tests/OneInside/main.cpp
-YOSYS_SCRIPT := tests/OneInside/yosys_script
+TOP_FILE := $(TEST_DIR)/dut.v
 TOP_MODULE := dut
-VERILATED_BIN := Vwork_$(TOP_MODULE)
-TOP_MAKEFILE := $(VERILATED_BIN).mk

--- a/tests/OneNetInterf/Makefile.in
+++ b/tests/OneNetInterf/Makefile.in
@@ -1,6 +1,2 @@
-TOP_FILE := Surelog/tests/OneNetInterf/dut.v
-MAIN_FILE := tests/OneNetInterf/main.cpp
-YOSYS_SCRIPT := tests/OneNetInterf/yosys_script
+TOP_FILE := $(root_dir)/Surelog/$(TEST)/dut.v
 TOP_MODULE := dut
-VERILATED_BIN := Vwork_$(TOP_MODULE)
-TOP_MAKEFILE := $(VERILATED_BIN).mk

--- a/tests/OneNetModport/Makefile.in
+++ b/tests/OneNetModport/Makefile.in
@@ -1,6 +1,2 @@
-TOP_FILE := tests/OneNetModport/top.sv
-MAIN_FILE := tests/OneNetModport/main.cpp
-YOSYS_SCRIPT := tests/OneNetModport/yosys_script
+TOP_FILE := $(TEST_DIR)/top.sv
 TOP_MODULE := top
-VERILATED_BIN := Vwork_$(TOP_MODULE)
-TOP_MAKEFILE := $(VERILATED_BIN).mk

--- a/tests/OneNetRange/Makefile.in
+++ b/tests/OneNetRange/Makefile.in
@@ -1,6 +1,2 @@
-TOP_FILE := Surelog/tests/OneNetRange/dut.v
-MAIN_FILE := tests/OneNetRange/main.cpp
-YOSYS_SCRIPT := tests/OneNetRange/yosys_script
+TOP_FILE := $(root_dir)/Surelog/$(TEST)/dut.v
 TOP_MODULE := dut
-VERILATED_BIN := Vwork_$(TOP_MODULE)
-TOP_MAKEFILE := $(VERILATED_BIN).mk

--- a/tests/OnePackage/Makefile.in
+++ b/tests/OnePackage/Makefile.in
@@ -1,6 +1,2 @@
-TOP_FILE := tests/OnePackage/dut.sv
-MAIN_FILE := tests/OnePackage/main.cpp
-YOSYS_SCRIPT := tests/OnePackage/yosys_script
+TOP_FILE := $(TEST_DIR)/dut.sv
 TOP_MODULE := dut
-VERILATED_BIN := Vwork_$(TOP_MODULE)
-TOP_MAKEFILE := $(VERILATED_BIN).mk

--- a/tests/OneReplicate/Makefile.in
+++ b/tests/OneReplicate/Makefile.in
@@ -1,6 +1,2 @@
-TOP_FILE := tests/OneReplicate/dut.v
-MAIN_FILE := tests/OneReplicate/main.cpp
-YOSYS_SCRIPT := tests/OneReplicate/yosys_script
+TOP_FILE := $(TEST_DIR)/dut.v
 TOP_MODULE := dut
-VERILATED_BIN := Vwork_$(TOP_MODULE)
-TOP_MAKEFILE := $(VERILATED_BIN).mk

--- a/tests/OneShift/Makefile.in
+++ b/tests/OneShift/Makefile.in
@@ -1,6 +1,2 @@
-TOP_FILE := tests/OneShift/dut.v
-MAIN_FILE := tests/OneShift/main.cpp
-YOSYS_SCRIPT := tests/OneShift/yosys_script
+TOP_FILE := $(TEST_DIR)/dut.v
 TOP_MODULE := dut
-VERILATED_BIN := Vwork_$(TOP_MODULE)
-TOP_MAKEFILE := $(VERILATED_BIN).mk

--- a/tests/OneStruct/Makefile.in
+++ b/tests/OneStruct/Makefile.in
@@ -1,6 +1,2 @@
-TOP_FILE := tests/OneStruct/dut.sv
-MAIN_FILE := tests/OneStruct/main.cpp
-YOSYS_SCRIPT := tests/OneStruct/yosys_script
+TOP_FILE := $(TEST_DIR)/dut.sv
 TOP_MODULE := dut
-VERILATED_BIN := Vwork_$(TOP_MODULE)
-TOP_MAKEFILE := $(VERILATED_BIN).mk

--- a/tests/OneSysFunc/Makefile.in
+++ b/tests/OneSysFunc/Makefile.in
@@ -1,6 +1,2 @@
-TOP_FILE := tests/OneSysFunc/dut.v
-MAIN_FILE := tests/OneSysFunc/main.cpp
-YOSYS_SCRIPT := tests/OneSysFunc/yosys_script
+TOP_FILE := $(TEST_DIR)/dut.v
 TOP_MODULE := dut
-VERILATED_BIN := Vwork_$(TOP_MODULE)
-TOP_MAKEFILE := $(VERILATED_BIN).mk

--- a/tests/OneThis/Makefile.in
+++ b/tests/OneThis/Makefile.in
@@ -1,6 +1,2 @@
-TOP_FILE := tests/OneThis/top.sv
-MAIN_FILE := tests/OneThis/main.cpp
-YOSYS_SCRIPT := tests/OneThis/yosys_script
+TOP_FILE := $(TEST_DIR)/top.sv
 TOP_MODULE := top
-VERILATED_BIN := Vwork_$(TOP_MODULE)
-TOP_MAKEFILE := $(VERILATED_BIN).mk

--- a/tests/OneThis/yosys_script
+++ b/tests/OneThis/yosys_script
@@ -1,0 +1,6 @@
+read_uhdm -debug top.uhdm
+write_json
+prep -top \dut
+write_verilog
+write_verilog yosys.sv
+sim -clock i -rstlen 10 -vcd dump.vcd

--- a/tests/PartSelect/Makefile.in
+++ b/tests/PartSelect/Makefile.in
@@ -1,6 +1,2 @@
-TOP_FILE := tests/PartSelect/top.sv
-MAIN_FILE := tests/PartSelect/main.cpp
-YOSYS_SCRIPT := tests/PartSelect/yosys_script
+TOP_FILE := $(TEST_DIR)/top.sv
 TOP_MODULE := top
-VERILATED_BIN := Vwork_$(TOP_MODULE)
-TOP_MAKEFILE := $(VERILATED_BIN).mk

--- a/tests/StructInPackage/Makefile.in
+++ b/tests/StructInPackage/Makefile.in
@@ -1,6 +1,2 @@
-TOP_FILE := tests/StructInPackage/dut.sv
-MAIN_FILE := tests/StructInPackage/main.cpp
-YOSYS_SCRIPT := tests/StructInPackage/yosys_script
+TOP_FILE := $(TEST_DIR)/dut.sv
 TOP_MODULE := dut
-VERILATED_BIN := Vwork_$(TOP_MODULE)
-TOP_MAKEFILE := $(VERILATED_BIN).mk

--- a/tests/StructInPackage/dut.sv
+++ b/tests/StructInPackage/dut.sv
@@ -10,14 +10,14 @@ package pkg2;
     } struct1;
 endpackage
 
-module dut;
+module dut(var1, var2, var3);
     typedef struct packed {
         logic [5:0] third;
     } struct2;
 
-    pkg1::struct1 var1;
-    pkg2::struct1 var2;
-    struct2 var3;
+    output pkg1::struct1 var1;
+    output pkg2::struct1 var2;
+    output struct2 var3;
 
     assign var1.first = 255;
     assign var2.second = 127;

--- a/tests/UnitForLoop/Makefile.in
+++ b/tests/UnitForLoop/Makefile.in
@@ -1,6 +1,2 @@
-TOP_FILE := tests/UnitForLoop/dut.v
-MAIN_FILE := tests/UnitForLoop/main.cpp
-YOSYS_SCRIPT := tests/UnitForLoop/yosys_script
+TOP_FILE := $(TEST_DIR)/dut.v
 TOP_MODULE := dut
-VERILATED_BIN := Vwork_$(TOP_MODULE)
-TOP_MAKEFILE := $(VERILATED_BIN).mk

--- a/tests/VarSelect/Makefile.in
+++ b/tests/VarSelect/Makefile.in
@@ -1,6 +1,2 @@
-TOP_FILE := tests/VarSelect/top.sv
-MAIN_FILE := tests/VarSelect/main.cpp
-YOSYS_SCRIPT := tests/VarSelect/yosys_script
+TOP_FILE := $(TEST_DIR)/top.sv
 TOP_MODULE := top
-VERILATED_BIN := Vwork_$(TOP_MODULE)
-TOP_MAKEFILE := $(VERILATED_BIN).mk

--- a/tests/fsm_single_always/Makefile.in
+++ b/tests/fsm_single_always/Makefile.in
@@ -1,6 +1,2 @@
-TOP_FILE := tests/fsm_single_always/dut.v
-MAIN_FILE := tests/fsm_single_always/main.cpp
-YOSYS_SCRIPT := tests/fsm_single_always/yosys_script
+TOP_FILE := $(TEST_DIR)/dut.v
 TOP_MODULE := fsm_using_single_always
-VERILATED_BIN := Vwork_$(TOP_MODULE)
-TOP_MAKEFILE := $(VERILATED_BIN).mk

--- a/tests/fsm_using_always/Makefile.in
+++ b/tests/fsm_using_always/Makefile.in
@@ -1,6 +1,2 @@
-TOP_FILE := tests/fsm_using_always/dut.v
-MAIN_FILE := tests/fsm_using_always/main.cpp
-YOSYS_SCRIPT := tests/fsm_using_always/yosys_script
+TOP_FILE := $(TEST_DIR)/dut.v
 TOP_MODULE := fsm_using_always
-VERILATED_BIN := Vwork_$(TOP_MODULE)
-TOP_MAKEFILE := $(VERILATED_BIN).mk

--- a/tests/fsm_using_function/Makefile.in
+++ b/tests/fsm_using_function/Makefile.in
@@ -1,6 +1,2 @@
-TOP_FILE := tests/fsm_using_function/dut.v
-MAIN_FILE := tests/fsm_using_function/main.cpp
-YOSYS_SCRIPT := tests/fsm_using_function/yosys_script
+TOP_FILE := $(TEST_DIR)/dut.v
 TOP_MODULE := fsm_using_function
-VERILATED_BIN := Vwork_$(TOP_MODULE)
-TOP_MAKEFILE := $(VERILATED_BIN).mk

--- a/tests/ibex/Makefile.in
+++ b/tests/ibex/Makefile.in
@@ -28,29 +28,23 @@ IBEX_SOURCES_SKIPPED = \
 		grep '${SKIP_SOURCES}' | \
                 sed 's@^..@${IBEX_BUILD}@')
 
-surelog/parse-ibex: surelog
-	mkdir -p ${root_dir}/build
+surelog/parse-ibex: image/bin/surelog clean-build
 	virtualenv ${root_dir}/venv-ibex
 	(. ${root_dir}/venv-ibex/bin/activate && \
 		cd ${IBEX} && pip install -r python-requirements.txt && \
 		fusesoc --cores-root=. run --target=synth --setup lowrisc:ibex:top_artya7 --part xc7a35ticsg324-1L && \
+		cd $(root_dir)/build && \
 	${root_dir}/image/bin/surelog -parse -sverilog \
 		-v ${root_dir}/yosys/techlibs/xilinx/cells_xtra_surelog.v \
 		$(IBEX_INCLUDE) \
 		$(IBEX_SOURCES) ${IBEX_PKG_SOURCES} && \
-	cp ${IBEX}/slpp_all/surelog.uhdm ${root_dir}/build/top.uhdm)
+	cp ${root_dir}/build/slpp_all/surelog.uhdm ${TOP_UHDM})
 
-uhdm/yosys/coverage: yosys/yosys surelog/parse-ibex
-	mkdir -p build
-	-(cd ${IBEX}/slpp_all && \
-		${YOSYS_BIN} \
-		-p "read_uhdm -report ${COVARAGE_REPORT} ${TOP_UHDM}")
 
 #############################
 ####      SYNTHESIS      ####
 #############################
-uhdm/yosys/synth-ibex: yosys/yosys surelog/parse-ibex
-	mkdir -p ${root_dir}/build
+uhdm/yosys/synth-ibex: image/bin/yosys surelog/parse-ibex
 	(cd ${root_dir}/build && \
 	${YOSYS_BIN} \
 		     -p 'read_uhdm ${TOP_UHDM}' \
@@ -67,7 +61,7 @@ uhdm/yosys/synth-ibex-build: uhdm/yosys/synth-ibex
 	(cd ${root_dir}/build && \
 		vivado -nojournal -log ${root_dir}/top.log -mode batch -source ${root_dir}/build.tcl)
 
-uhdm/yosys/synth-ibex-sv: yosys/yosys
+uhdm/yosys/synth-ibex-sv: image/bin/yosys
 	mkdir -p ${root_dir}/build-sv
 	(cd ${root_dir}/build-sv && \
 	${YOSYS_BIN} \
@@ -89,7 +83,7 @@ ifeq ($(SIM_FILE),ibex_alu.sv)
 	SIM_FILES := $(SIM_FILES) $(IBEX_TOP_DIR)/ibex_alu_top.sv $(IBEX_DIR)/ibex_pkg.sv
 endif
 
-surelog/parse-sim: surelog
+surelog/parse-sim: image/bin/surelog
 	mkdir -p build
 	(cd build && \
 		${SURELOG_BIN} -parse -sverilog \
@@ -98,7 +92,7 @@ surelog/parse-sim: surelog
 	)
 	cp build/slpp_all/surelog.uhdm build/top.uhdm
 
-uhdm/yosys/test-sim: surelog/parse-sim yosys/yosys
+uhdm/yosys/test-sim: surelog/parse-sim image/bin/yosys
 	${YOSYS_BIN} \
 		-p 'read_uhdm -debug build/top.uhdm' \
 		-p 'prep -auto-top' \

--- a/tests/onenet/Makefile.in
+++ b/tests/onenet/Makefile.in
@@ -1,6 +1,2 @@
-TOP_FILE := tests/onenet/top.sv
-MAIN_FILE := tests/onenet/main.cpp
-YOSYS_SCRIPT := tests/onenet/yosys_script
+TOP_FILE := $(TEST_DIR)/top.sv
 TOP_MODULE := top
-VERILATED_BIN := Vwork_$(TOP_MODULE)
-TOP_MAKEFILE := $(VERILATED_BIN).mk


### PR DESCRIPTION
This PR:

- Moves building binaries to single step and shares them between all other steps
- Dynamically generates build matrix
- Enables full-flow comparison (uhdm/vcddiff) (it was disabled earlier due to timeouts in Travis)