### PR TITLE
Fix GH-actions RPC failed error

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,7 @@ jobs:
     - uses: actions/checkout@v2
       with:
         submodules: recursive
-        fetch-depth: 0
+        fetch-depth: 1
 
     - uses: actions/setup-python@v2
       with:
@@ -87,7 +87,7 @@ jobs:
     - uses: actions/checkout@v2
       with:
         submodules: recursive
-        fetch-depth: 0
+        fetch-depth: 1
 
     - uses: actions/setup-python@v2
       with:
@@ -131,7 +131,7 @@ jobs:
     - uses: actions/checkout@v2
       with:
         submodules: recursive
-        fetch-depth: 0
+        fetch-depth: 1
 
     - uses: actions/setup-python@v2
       with:
@@ -179,7 +179,7 @@ jobs:
     - uses: actions/checkout@v2
       with:
         submodules: recursive
-        fetch-depth: 0
+        fetch-depth: 1
 
     - uses: actions/setup-python@v2
       with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -76,6 +76,9 @@ jobs:
     env:
       CC: gcc-9
       CXX: g++-9
+      GIT_HTTP_LOW_SPEED_LIMIT: 1
+      GIT_HTTP_LOW_SPEED_TIME: 600
+      GIT_CURL_VERBOSE: 1
 
     steps:
 


### PR DESCRIPTION
This PR tries to fix RPC failed error when cloning submodules in GH-actions by reducing ``fetch-depth`` from ``0`` (fetch all history for all branches and tags) to ``1``:
```
2020-12-04T10:56:28.7363223Z ##[error]error: RPC failed; curl 18 transfer closed with outstanding read data remaining
2020-12-04T10:56:28.7387220Z ##[error]fatal: expected flush after ref listing
2020-12-04T10:56:28.7394196Z ##[error]fatal: clone of 'https://github.com/antmicro/verilator.git' into submodule path '/home/runner/work/uhdm-integration/uhdm-integration/verilator' failed
2020-12-04T10:56:28.7405659Z Failed to clone 'verilator' a second time, aborting
2020-12-04T10:56:28.7499146Z ##[error]The process '/usr/bin/git' failed with exit code 1
```

Signed-off-by: Kamil Rakoczy <krakoczy@antmicro.com>