### PR TITLE
Add unary operators tests

### DIFF
--- a/tests/simple_unary_op_minus/Makefile.in
+++ b/tests/simple_unary_op_minus/Makefile.in
@@ -1,0 +1,2 @@
+TOP_FILE := $(TEST_DIR)/simple_unary_op_minus.sv
+TOP_MODULE := top

--- a/tests/simple_unary_op_minus/main.cpp
+++ b/tests/simple_unary_op_minus/main.cpp
@@ -1,0 +1,36 @@
+#include <iostream>
+#include <verilated_vcd_c.h>
+
+#define VL_DEBUG
+#include "Vtop.h"
+#include "verilated.h"
+
+static vluint64_t main_time = 0;
+
+double
+sc_time_stamp()
+{
+  return main_time;
+}
+
+int main (int argc, char **argv) {
+  Verilated::commandArgs(argc, argv);
+  Vtop *top = new Vtop();
+
+  Verilated::traceEverOn(true);
+  VerilatedVcdC* tfp = new VerilatedVcdC;
+  top->trace(tfp, 99);
+  tfp->open("dump.vcd");
+
+  while (!Verilated::gotFinish() && (main_time < 100)) {
+    top->eval();
+    tfp->dump(main_time);
+
+    main_time += 1;
+  }
+  top->final();
+  tfp->close();
+    delete top;
+
+  return 0;
+}

--- a/tests/simple_unary_op_minus/simple_unary_op_minus.sv
+++ b/tests/simple_unary_op_minus/simple_unary_op_minus.sv
@@ -1,0 +1,8 @@
+/*
+:name: simple_unary_op_minus
+:description: minimal - operator simulation test (without result verification)
+:tags: 11.3
+*/
+module top(input [3:0] a, output [3:0] b);
+    assign b = -a;
+endmodule

--- a/tests/simple_unary_op_minus/yosys_script
+++ b/tests/simple_unary_op_minus/yosys_script
@@ -1,0 +1,6 @@
+read_uhdm -debug top.uhdm
+write_json
+prep -top \top
+write_verilog
+write_verilog yosys.sv
+sim -rstlen 10 -vcd dump.vcd

--- a/tests/simple_unary_op_not_log/Makefile.in
+++ b/tests/simple_unary_op_not_log/Makefile.in
@@ -1,2 +1,3 @@
 TOP_FILE := $(TEST_DIR)/simple_unary_op_not_log.sv
 TOP_MODULE := top
+VERILATOR_FLAGS := $(TEST_DIR)/config.vlt

--- a/tests/simple_unary_op_not_log/Makefile.in
+++ b/tests/simple_unary_op_not_log/Makefile.in
@@ -1,0 +1,2 @@
+TOP_FILE := $(TEST_DIR)/simple_unary_op_not_log.sv
+TOP_MODULE := top

--- a/tests/simple_unary_op_not_log/config.vlt
+++ b/tests/simple_unary_op_not_log/config.vlt
@@ -1,0 +1,2 @@
+  `verilator_config
+  lint_off -rule WIDTH

--- a/tests/simple_unary_op_not_log/main.cpp
+++ b/tests/simple_unary_op_not_log/main.cpp
@@ -1,0 +1,36 @@
+#include <iostream>
+#include <verilated_vcd_c.h>
+
+#define VL_DEBUG
+#include "Vtop.h"
+#include "verilated.h"
+
+static vluint64_t main_time = 0;
+
+double
+sc_time_stamp()
+{
+  return main_time;
+}
+
+int main (int argc, char **argv) {
+  Verilated::commandArgs(argc, argv);
+  Vtop *top = new Vtop();
+
+  Verilated::traceEverOn(true);
+  VerilatedVcdC* tfp = new VerilatedVcdC;
+  top->trace(tfp, 99);
+  tfp->open("dump.vcd");
+
+  while (!Verilated::gotFinish() && (main_time < 100)) {
+    top->eval();
+    tfp->dump(main_time);
+
+    main_time += 1;
+  }
+  top->final();
+  tfp->close();
+    delete top;
+
+  return 0;
+}

--- a/tests/simple_unary_op_not_log/simple_unary_op_not_log.sv
+++ b/tests/simple_unary_op_not_log/simple_unary_op_not_log.sv
@@ -1,0 +1,8 @@
+/*
+:name: simple_unary_op_not_log
+:description: minimal ! operator simulation test (without result verification)
+:tags: 11.3
+*/
+module top(input [3:0] a, output [3:0] b);
+    assign b = !a;
+endmodule

--- a/tests/simple_unary_op_not_log/yosys_script
+++ b/tests/simple_unary_op_not_log/yosys_script
@@ -1,0 +1,6 @@
+read_uhdm -debug top.uhdm
+write_json
+prep -top \top
+write_verilog
+write_verilog yosys.sv
+sim -rstlen 10 -vcd dump.vcd

--- a/tests/simple_unary_op_plus/Makefile.in
+++ b/tests/simple_unary_op_plus/Makefile.in
@@ -1,0 +1,2 @@
+TOP_FILE := $(TEST_DIR)/simple_unary_op_plus.sv
+TOP_MODULE := top

--- a/tests/simple_unary_op_plus/main.cpp
+++ b/tests/simple_unary_op_plus/main.cpp
@@ -1,0 +1,36 @@
+#include <iostream>
+#include <verilated_vcd_c.h>
+
+#define VL_DEBUG
+#include "Vtop.h"
+#include "verilated.h"
+
+static vluint64_t main_time = 0;
+
+double
+sc_time_stamp()
+{
+  return main_time;
+}
+
+int main (int argc, char **argv) {
+  Verilated::commandArgs(argc, argv);
+  Vtop *top = new Vtop();
+
+  Verilated::traceEverOn(true);
+  VerilatedVcdC* tfp = new VerilatedVcdC;
+  top->trace(tfp, 99);
+  tfp->open("dump.vcd");
+
+  while (!Verilated::gotFinish() && (main_time < 100)) {
+    top->eval();
+    tfp->dump(main_time);
+
+    main_time += 1;
+  }
+  top->final();
+  tfp->close();
+    delete top;
+
+  return 0;
+}

--- a/tests/simple_unary_op_plus/simple_unary_op_plus.sv
+++ b/tests/simple_unary_op_plus/simple_unary_op_plus.sv
@@ -1,0 +1,8 @@
+/*
+:name: simple_unary_op_plus
+:description: minimal + operator simulation test (without result verification)
+:tags: 11.3
+*/
+module top(input [3:0] a, output [3:0] b);
+    assign b = +a;
+endmodule

--- a/tests/simple_unary_op_plus/yosys_script
+++ b/tests/simple_unary_op_plus/yosys_script
@@ -1,0 +1,6 @@
+read_uhdm -debug top.uhdm
+write_json
+prep -top \top
+write_verilog
+write_verilog yosys.sv
+sim -rstlen 10 -vcd dump.vcd

--- a/tests/unary_op_minus/Makefile.in
+++ b/tests/unary_op_minus/Makefile.in
@@ -1,0 +1,2 @@
+TOP_FILE := $(TEST_DIR)/unary_op_minus.sv
+TOP_MODULE := top

--- a/tests/unary_op_minus/main.cpp
+++ b/tests/unary_op_minus/main.cpp
@@ -1,0 +1,36 @@
+#include <iostream>
+#include <verilated_vcd_c.h>
+
+#define VL_DEBUG
+#include "Vtop.h"
+#include "verilated.h"
+
+static vluint64_t main_time = 0;
+
+double
+sc_time_stamp()
+{
+  return main_time;
+}
+
+int main (int argc, char **argv) {
+  Verilated::commandArgs(argc, argv);
+  Vtop *top = new Vtop();
+
+  Verilated::traceEverOn(true);
+  VerilatedVcdC* tfp = new VerilatedVcdC;
+  top->trace(tfp, 99);
+  tfp->open("dump.vcd");
+
+  while (!Verilated::gotFinish() && (main_time < 100)) {
+    top->eval();
+    tfp->dump(main_time);
+
+    main_time += 1;
+  }
+  top->final();
+  tfp->close();
+    delete top;
+
+  return 0;
+}

--- a/tests/unary_op_minus/unary_op_minus.sv
+++ b/tests/unary_op_minus/unary_op_minus.sv
@@ -1,0 +1,12 @@
+/*
+:name: unary_op_minus
+:description: - operator test
+:tags: 11.3
+*/
+module top();
+int a = 12;
+int b = 5;
+initial begin
+    a = -b;
+end
+endmodule

--- a/tests/unary_op_minus/yosys_script
+++ b/tests/unary_op_minus/yosys_script
@@ -1,0 +1,6 @@
+read_uhdm -debug top.uhdm
+write_json
+prep -top \top
+write_verilog
+write_verilog yosys.sv
+sim -rstlen 10 -vcd dump.vcd

--- a/tests/unary_op_not_log/Makefile.in
+++ b/tests/unary_op_not_log/Makefile.in
@@ -1,0 +1,2 @@
+TOP_FILE := $(TEST_DIR)/unary_op_not_log.sv
+TOP_MODULE := top

--- a/tests/unary_op_not_log/Makefile.in
+++ b/tests/unary_op_not_log/Makefile.in
@@ -1,2 +1,3 @@
 TOP_FILE := $(TEST_DIR)/unary_op_not_log.sv
 TOP_MODULE := top
+VERILATOR_FLAGS := $(TEST_DIR)/config.vlt

--- a/tests/unary_op_not_log/config.vlt
+++ b/tests/unary_op_not_log/config.vlt
@@ -1,0 +1,2 @@
+  `verilator_config
+  lint_off -rule WIDTH

--- a/tests/unary_op_not_log/main.cpp
+++ b/tests/unary_op_not_log/main.cpp
@@ -1,0 +1,36 @@
+#include <iostream>
+#include <verilated_vcd_c.h>
+
+#define VL_DEBUG
+#include "Vtop.h"
+#include "verilated.h"
+
+static vluint64_t main_time = 0;
+
+double
+sc_time_stamp()
+{
+  return main_time;
+}
+
+int main (int argc, char **argv) {
+  Verilated::commandArgs(argc, argv);
+  Vtop *top = new Vtop();
+
+  Verilated::traceEverOn(true);
+  VerilatedVcdC* tfp = new VerilatedVcdC;
+  top->trace(tfp, 99);
+  tfp->open("dump.vcd");
+
+  while (!Verilated::gotFinish() && (main_time < 100)) {
+    top->eval();
+    tfp->dump(main_time);
+
+    main_time += 1;
+  }
+  top->final();
+  tfp->close();
+    delete top;
+
+  return 0;
+}

--- a/tests/unary_op_not_log/unary_op_not_log.sv
+++ b/tests/unary_op_not_log/unary_op_not_log.sv
@@ -1,0 +1,12 @@
+/*
+:name: unary_op_not_log
+:description: ! operator test
+:tags: 11.3
+*/
+module top();
+int a = 12;
+int b = 5;
+initial begin
+    a = !b;
+end
+endmodule

--- a/tests/unary_op_not_log/yosys_script
+++ b/tests/unary_op_not_log/yosys_script
@@ -1,0 +1,6 @@
+read_uhdm -debug top.uhdm
+write_json
+prep -top \top
+write_verilog
+write_verilog yosys.sv
+sim -rstlen 10 -vcd dump.vcd

--- a/tests/unary_op_plus/Makefile.in
+++ b/tests/unary_op_plus/Makefile.in
@@ -1,0 +1,2 @@
+TOP_FILE := $(TEST_DIR)/unary_op_plus.sv
+TOP_MODULE := top

--- a/tests/unary_op_plus/main.cpp
+++ b/tests/unary_op_plus/main.cpp
@@ -1,0 +1,36 @@
+#include <iostream>
+#include <verilated_vcd_c.h>
+
+#define VL_DEBUG
+#include "Vtop.h"
+#include "verilated.h"
+
+static vluint64_t main_time = 0;
+
+double
+sc_time_stamp()
+{
+  return main_time;
+}
+
+int main (int argc, char **argv) {
+  Verilated::commandArgs(argc, argv);
+  Vtop *top = new Vtop();
+
+  Verilated::traceEverOn(true);
+  VerilatedVcdC* tfp = new VerilatedVcdC;
+  top->trace(tfp, 99);
+  tfp->open("dump.vcd");
+
+  while (!Verilated::gotFinish() && (main_time < 100)) {
+    top->eval();
+    tfp->dump(main_time);
+
+    main_time += 1;
+  }
+  top->final();
+  tfp->close();
+    delete top;
+
+  return 0;
+}

--- a/tests/unary_op_plus/unary_op_plus.sv
+++ b/tests/unary_op_plus/unary_op_plus.sv
@@ -1,0 +1,12 @@
+/*
+:name: unary_op_plus
+:description: + operator test
+:tags: 11.3
+*/
+module top();
+int a = 12;
+int b = 5;
+initial begin
+    a = +b;
+end
+endmodule

--- a/tests/unary_op_plus/yosys_script
+++ b/tests/unary_op_plus/yosys_script
@@ -1,0 +1,6 @@
+read_uhdm -debug top.uhdm
+write_json
+prep -top \top
+write_verilog
+write_verilog yosys.sv
+sim -rstlen 10 -vcd dump.vcd


### PR DESCRIPTION
This PR adds tests for basic unary operators: `+`, `-`, `!`

Signed-off-by: Paweł Czarnecki <pczarnecki@antmicro.com>