### PR TITLE
Disable parameter substitution by Surelog in relevant tests

### DIFF
--- a/tests/ibex/module_tests/core/Makefile.in
+++ b/tests/ibex/module_tests/core/Makefile.in
@@ -26,5 +26,5 @@ TOP_FILE := \
     $(IBEX_BUILD)/src/lowrisc_ibex_ibex_core_0.1/rtl/ibex_core.sv
 TOP_MODULE := ibex_core
 INCLUDE := -I$(IBEX_BUILD)/src/lowrisc_prim_assert_0.1/rtl/
-SURELOG_FLAGS := +define+SYNTHESIS
+SURELOG_FLAGS := --disable-feature=parametersubstitution +define+SYNTHESIS
 VERILATOR_FLAGS := --cc $(TEST_DIR)/config.vlt

--- a/tests/ibex/module_tests/cs_registers/Makefile.in
+++ b/tests/ibex/module_tests/cs_registers/Makefile.in
@@ -6,4 +6,4 @@ TOP_FILE := \
     $(IBEX_BUILD)/src/lowrisc_ibex_ibex_core_0.1/rtl/ibex_cs_registers.sv
 TOP_MODULE := ibex_cs_registers
 INCLUDE := -I$(IBEX_BUILD)/src/lowrisc_prim_assert_0.1/rtl/
-SURELOG_FLAGS := +define+SYNTHESIS
+SURELOG_FLAGS := --disable-feature=parametersubstitution +define+SYNTHESIS


### PR DESCRIPTION
This change is needed for the tests to pass in Verilator with latest Surelog.
Related to https://github.com/alainmarcel/Surelog/pull/1021