### PR TITLE
Add module test for prim_generic_flop

### DIFF
--- a/tests/opentitan/module_tests/prim_generic_clock_gating/Makefile.in
+++ b/tests/opentitan/module_tests/prim_generic_clock_gating/Makefile.in
@@ -1,7 +1,7 @@
 include $(TEST_DIR)/../Makefile.in
 TOP_FILE := \
-    $(OPENTITAN_BUILD)/src/lowrisc_prim_abstract_prim_pkg_0.1/prim_pkg.sv \
-    $(OPENTITAN_BUILD)/src/lowrisc_prim_generic_clock_gating_0/rtl/prim_generic_clock_gating.sv \
-    $(OPENTITAN_BUILD)/src/lowrisc_prim_abstract_clock_gating_0/prim_clock_gating.sv
+    $(OPEN_TITAN_BUILD)/src/lowrisc_prim_abstract_prim_pkg_0.1/prim_pkg.sv \
+    $(OPEN_TITAN_BUILD)/src/lowrisc_prim_generic_clock_gating_0/rtl/prim_generic_clock_gating.sv \
+    $(OPEN_TITAN_BUILD)/src/lowrisc_prim_abstract_clock_gating_0/prim_clock_gating.sv
 
 TOP_MODULE := prim_clock_gating

--- a/tests/opentitan/module_tests/prim_generic_flop/Makefile.in
+++ b/tests/opentitan/module_tests/prim_generic_flop/Makefile.in
@@ -1,0 +1,7 @@
+include $(TEST_DIR)/../Makefile.in
+TOP_FILE := \
+    $(OPEN_TITAN_BUILD)/src/lowrisc_prim_generic_flop_0/rtl/prim_generic_flop.sv
+
+INCLUDE := -I$(OPEN_TITAN_BUILD)/src/lowrisc_prim_assert_0.1/rtl/
+
+TOP_MODULE := prim_generic_flop

--- a/tests/opentitan/module_tests/prim_generic_flop/main.cpp
+++ b/tests/opentitan/module_tests/prim_generic_flop/main.cpp
@@ -29,13 +29,20 @@ int main (int argc, char **argv) {
     top->eval();
     tfp->dump(main_time);
 
+    main_time += 1;
     top->clk_i ^= 1;
     if (main_time > 10)
       top->rst_ni = 1;
-    if (main_time%2)
+    if (top->clk_i % 2)
       top->d_i ^= 1;
 
-    main_time += 1;
+    std::cout << "time: " << main_time
+      << " rst_ni: " << (top->rst_ni ? 0 : 1)
+      << " clk_i: " << (top->clk_i ? 0 : 1)
+      << " d_i: " << (top->d_i ? 0 : 1)
+      << " q_o: " << (top->q_o ? 0 : 1)
+      << std::endl;
+
   }
   top->final();
   tfp->close();

--- a/tests/opentitan/module_tests/prim_generic_flop/main.cpp
+++ b/tests/opentitan/module_tests/prim_generic_flop/main.cpp
@@ -1,0 +1,45 @@
+#include <iostream>
+#include <verilated_vcd_c.h>
+
+#define VL_DEBUG
+#include "Vprim_generic_flop.h"
+#include "verilated.h"
+
+static vluint64_t main_time = 0;
+
+double
+sc_time_stamp()
+{
+  return main_time;
+}
+
+int main (int argc, char **argv) {
+  Verilated::commandArgs(argc, argv);
+  Vprim_generic_flop *top = new Vprim_generic_flop();
+
+  Verilated::traceEverOn(true);
+  VerilatedVcdC* tfp = new VerilatedVcdC;
+  top->trace(tfp, 99);
+  tfp->open("dump.vcd");
+
+  top->clk_i = 0;
+  top->rst_ni = 0;
+  top->d_i = 0;
+  while (!Verilated::gotFinish() && (main_time < 100)) {
+    top->eval();
+    tfp->dump(main_time);
+
+    top->clk_i ^= 1;
+    if (main_time > 10)
+      top->rst_ni = 1;
+    if (main_time%2)
+      top->d_i ^= 1;
+
+    main_time += 1;
+  }
+  top->final();
+  tfp->close();
+    delete top;
+
+  return 0;
+}

--- a/tests/opentitan/module_tests/ram_1p/Makefile.in
+++ b/tests/opentitan/module_tests/ram_1p/Makefile.in
@@ -1,8 +1,8 @@
 include $(TEST_DIR)/../Makefile.in
 TOP_FILE := \
-    $(OPENTITAN_BUILD)/src/lowrisc_prim_generic_ram_1p_0/rtl/prim_generic_ram_1p.sv \
-    $(OPENTITAN_BUILD)/src/lowrisc_prim_abstract_ram_1p_0/prim_ram_1p.sv
+    $(OPEN_TITAN_BUILD)/src/lowrisc_prim_generic_ram_1p_0/rtl/prim_generic_ram_1p.sv \
+    $(OPEN_TITAN_BUILD)/src/lowrisc_prim_abstract_ram_1p_0/prim_ram_1p.sv
 
-INCLUDE := -I$(OPENTITAN_BUILD)/src/lowrisc_prim_assert_0.1/rtl/ -I$(OPENTITAN_BUILD)/src/lowrisc_prim_util_memload_0/rtl/
+INCLUDE := -I$(OPEN_TITAN_BUILD)/src/lowrisc_prim_assert_0.1/rtl/ -I$(OPEN_TITAN_BUILD)/src/lowrisc_prim_util_memload_0/rtl/
 
 TOP_MODULE := prim_ram_1p


### PR DESCRIPTION
This PR adds individual module test for prim_generic_flop.sv and updates other tests so that they can be run in Verilator CI.