### PR TITLE
Add tests for prim_flop modules

### DIFF
--- a/tests/opentitan/module_tests/prim_flop/Makefile.in
+++ b/tests/opentitan/module_tests/prim_flop/Makefile.in
@@ -1,0 +1,10 @@
+include $(TEST_DIR)/../Makefile.in
+TOP_FILE := \
+    $(OPEN_TITAN_BUILD)/src/lowrisc_prim_abstract_prim_pkg_0.1/prim_pkg.sv \
+    $(OPEN_TITAN_BUILD)/src/lowrisc_prim_generic_flop_0/rtl/prim_generic_flop.sv \
+    $(OPEN_TITAN_BUILD)/src/lowrisc_prim_xilinx_flop_0/rtl/prim_xilinx_flop.sv \
+    $(OPEN_TITAN_BUILD)/src/lowrisc_prim_abstract_flop_0/prim_flop.sv
+
+INCLUDE := -I$(OPEN_TITAN_BUILD)/src/lowrisc_prim_assert_0.1/rtl/
+
+TOP_MODULE := prim_flop

--- a/tests/opentitan/module_tests/prim_flop/main.cpp
+++ b/tests/opentitan/module_tests/prim_flop/main.cpp
@@ -1,0 +1,52 @@
+#include <iostream>
+#include <verilated_vcd_c.h>
+
+#define VL_DEBUG
+#include "Vprim_flop.h"
+#include "verilated.h"
+
+static vluint64_t main_time = 0;
+
+double
+sc_time_stamp()
+{
+  return main_time;
+}
+
+int main (int argc, char **argv) {
+  Verilated::commandArgs(argc, argv);
+  Vprim_flop *top = new Vprim_flop();
+
+  Verilated::traceEverOn(true);
+  VerilatedVcdC* tfp = new VerilatedVcdC;
+  top->trace(tfp, 99);
+  tfp->open("dump.vcd");
+
+  top->clk_i = 0;
+  top->rst_ni = 0;
+  top->d_i = 0;
+  while (!Verilated::gotFinish() && (main_time < 100)) {
+    top->eval();
+    tfp->dump(main_time);
+
+    main_time += 1;
+    top->clk_i ^= 1;
+    if (main_time > 10)
+      top->rst_ni = 1;
+    if (top->clk_i % 2)
+      top->d_i ^= 1;
+
+    std::cout << "time: " << main_time
+      << " rst_ni: " << (top->rst_ni ? 0 : 1)
+      << " clk_i: " << (top->clk_i ? 0 : 1)
+      << " d_i: " << (top->d_i ? 0 : 1)
+      << " q_o: " << (top->q_o ? 0 : 1)
+      << std::endl;
+
+  }
+  top->final();
+  tfp->close();
+    delete top;
+
+  return 0;
+}

--- a/tests/opentitan/module_tests/prim_flop_2sync/Makefile.in
+++ b/tests/opentitan/module_tests/prim_flop_2sync/Makefile.in
@@ -1,0 +1,12 @@
+include $(TEST_DIR)/../Makefile.in
+TOP_FILE := \
+    $(OPEN_TITAN_BUILD)/src/lowrisc_prim_abstract_prim_pkg_0.1/prim_pkg.sv \
+    $(OPEN_TITAN_BUILD)/src/lowrisc_prim_generic_flop_0/rtl/prim_generic_flop.sv \
+    $(OPEN_TITAN_BUILD)/src/lowrisc_prim_xilinx_flop_0/rtl/prim_xilinx_flop.sv \
+    $(OPEN_TITAN_BUILD)/src/lowrisc_prim_abstract_flop_0/prim_flop.sv \
+    $(OPEN_TITAN_BUILD)/src/lowrisc_prim_generic_flop_2sync_0/rtl/prim_generic_flop_2sync.sv \
+    $(OPEN_TITAN_BUILD)/src/lowrisc_prim_abstract_flop_2sync_0/prim_flop_2sync.sv
+
+INCLUDE := -I$(OPEN_TITAN_BUILD)/src/lowrisc_prim_assert_0.1/rtl/
+
+TOP_MODULE := prim_flop_2sync

--- a/tests/opentitan/module_tests/prim_flop_2sync/main.cpp
+++ b/tests/opentitan/module_tests/prim_flop_2sync/main.cpp
@@ -1,0 +1,52 @@
+#include <iostream>
+#include <verilated_vcd_c.h>
+
+#define VL_DEBUG
+#include "Vprim_flop_2sync.h"
+#include "verilated.h"
+
+static vluint64_t main_time = 0;
+
+double
+sc_time_stamp()
+{
+  return main_time;
+}
+
+int main (int argc, char **argv) {
+  Verilated::commandArgs(argc, argv);
+  Vprim_flop_2sync *top = new Vprim_flop_2sync();
+
+  Verilated::traceEverOn(true);
+  VerilatedVcdC* tfp = new VerilatedVcdC;
+  top->trace(tfp, 99);
+  tfp->open("dump.vcd");
+
+  top->clk_i = 0;
+  top->rst_ni = 0;
+  top->d_i = 0;
+  while (!Verilated::gotFinish() && (main_time < 100)) {
+    top->eval();
+    tfp->dump(main_time);
+
+    main_time += 1;
+    top->clk_i ^= 1;
+    if (main_time > 10)
+      top->rst_ni = 1;
+    if (top->clk_i % 2)
+      top->d_i ^= 1;
+
+    std::cout << "time: " << main_time
+      << " rst_ni: " << (top->rst_ni ? 0 : 1)
+      << " clk_i: " << (top->clk_i ? 0 : 1)
+      << " d_i: " << (top->d_i ? 0 : 1)
+      << " q_o: " << (top->q_o ? 0 : 1)
+      << std::endl;
+
+  }
+  top->final();
+  tfp->close();
+    delete top;
+
+  return 0;
+}

--- a/tests/opentitan/module_tests/prim_generic_flop_2sync/Makefile.in
+++ b/tests/opentitan/module_tests/prim_generic_flop_2sync/Makefile.in
@@ -1,0 +1,11 @@
+include $(TEST_DIR)/../Makefile.in
+TOP_FILE := \
+    $(OPEN_TITAN_BUILD)/src/lowrisc_prim_abstract_prim_pkg_0.1/prim_pkg.sv \
+    $(OPEN_TITAN_BUILD)/src/lowrisc_prim_generic_flop_0/rtl/prim_generic_flop.sv \
+    $(OPEN_TITAN_BUILD)/src/lowrisc_prim_xilinx_flop_0/rtl/prim_xilinx_flop.sv \
+    $(OPEN_TITAN_BUILD)/src/lowrisc_prim_abstract_flop_0/prim_flop.sv \
+    $(OPEN_TITAN_BUILD)/src/lowrisc_prim_generic_flop_2sync_0/rtl/prim_generic_flop_2sync.sv
+
+INCLUDE := -I$(OPEN_TITAN_BUILD)/src/lowrisc_prim_assert_0.1/rtl/
+
+TOP_MODULE := prim_generic_flop_2sync

--- a/tests/opentitan/module_tests/prim_generic_flop_2sync/main.cpp
+++ b/tests/opentitan/module_tests/prim_generic_flop_2sync/main.cpp
@@ -1,0 +1,52 @@
+#include <iostream>
+#include <verilated_vcd_c.h>
+
+#define VL_DEBUG
+#include "Vprim_generic_flop_2sync.h"
+#include "verilated.h"
+
+static vluint64_t main_time = 0;
+
+double
+sc_time_stamp()
+{
+  return main_time;
+}
+
+int main (int argc, char **argv) {
+  Verilated::commandArgs(argc, argv);
+  Vprim_generic_flop_2sync *top = new Vprim_generic_flop_2sync();
+
+  Verilated::traceEverOn(true);
+  VerilatedVcdC* tfp = new VerilatedVcdC;
+  top->trace(tfp, 99);
+  tfp->open("dump.vcd");
+
+  top->clk_i = 0;
+  top->rst_ni = 0;
+  top->d_i = 0;
+  while (!Verilated::gotFinish() && (main_time < 100)) {
+    top->eval();
+    tfp->dump(main_time);
+
+    main_time += 1;
+    top->clk_i ^= 1;
+    if (main_time > 10)
+      top->rst_ni = 1;
+    if (top->clk_i % 2)
+      top->d_i ^= 1;
+
+    std::cout << "time: " << main_time
+      << " rst_ni: " << (top->rst_ni ? 0 : 1)
+      << " clk_i: " << (top->clk_i ? 0 : 1)
+      << " d_i: " << (top->d_i ? 0 : 1)
+      << " q_o: " << (top->q_o ? 0 : 1)
+      << std::endl;
+
+  }
+  top->final();
+  tfp->close();
+    delete top;
+
+  return 0;
+}


### PR DESCRIPTION
This PR adds individual module tests for Earlgrey modules:
* prim_flop
* prim_generic_flop_2sync
* prim_flop_2sync