### PR TITLE
Fix typos in prim module tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -111,7 +111,9 @@ surelog/ibex-simplesystem: clean-build
 uhdm/verilator/get-ast: clean-build
 	(cd $(root_dir)/build && \
 		$(VERILATOR_BIN) --cc $(TOP_FILE) \
+			$(INCLUDE) \
 			$(VERILATOR_FLAGS) \
+			--top-module ${TOP_MODULE} \
 			--exe $(MAIN_FILE) --debug --xml-only)
 
 uhdm/verilator/ast-xml: surelog/parse
@@ -121,6 +123,22 @@ uhdm/verilator/ast-xml: surelog/parse
 			--dump-uhdm \
 			--debugi 6 \
 			--exe $(MAIN_FILE) --xml-only)
+
+verilator/test-ast:
+	mkdir -p $(root_dir)/dumps
+	(cd $(root_dir)/build && \
+		$(VERILATOR_BIN) \
+			$(INCLUDE) \
+			--cc $(TOP_FILE) \
+			$(VERILATOR_FLAGS) \
+			--top-module ${TOP_MODULE} \
+			--exe $(MAIN_FILE) --trace && \
+		 make -j -C obj_dir -f $(TOP_MAKEFILE) $(VERILATED_BIN) && \
+		 obj_dir/$(VERILATED_BIN))
+	mv $(root_dir)/build/dump.vcd $(root_dir)/dumps/dump_vanilla.vcd
+
+uhdm/verilator/vcddiff: verilator/test-ast uhdm/verilator/test-ast
+	$(VCDDIFF_BIN) $(root_dir)/dumps/dump_vanilla.vcd $(root_dir)/dumps/dump_verilator.vcd
 
 vcd:
 	gtkwave $(root_dir)/build/dump.vcd &>/dev/null &

--- a/tests/opentitan/module_tests/prim_flop/main.cpp
+++ b/tests/opentitan/module_tests/prim_flop/main.cpp
@@ -37,10 +37,10 @@ int main (int argc, char **argv) {
       top->d_i ^= 1;
 
     std::cout << "time: " << main_time
-      << " rst_ni: " << (top->rst_ni ? 0 : 1)
-      << " clk_i: " << (top->clk_i ? 0 : 1)
-      << " d_i: " << (top->d_i ? 0 : 1)
-      << " q_o: " << (top->q_o ? 0 : 1)
+      << " rst_ni: " << (top->rst_ni ? 1 : 0)
+      << " clk_i: " << (top->clk_i ? 1 : 0)
+      << " d_i: " << (top->d_i ? 1 : 0)
+      << " q_o: " << (top->q_o ? 1 : 0)
       << std::endl;
 
   }

--- a/tests/opentitan/module_tests/prim_flop_2sync/main.cpp
+++ b/tests/opentitan/module_tests/prim_flop_2sync/main.cpp
@@ -37,10 +37,10 @@ int main (int argc, char **argv) {
       top->d_i ^= 1;
 
     std::cout << "time: " << main_time
-      << " rst_ni: " << (top->rst_ni ? 0 : 1)
-      << " clk_i: " << (top->clk_i ? 0 : 1)
-      << " d_i: " << (top->d_i ? 0 : 1)
-      << " q_o: " << (top->q_o ? 0 : 1)
+      << " rst_ni: " << (top->rst_ni ? 1 : 0)
+      << " clk_i: " << (top->clk_i ? 1 : 0)
+      << " d_i: " << (top->d_i ? 1 : 0)
+      << " q_o: " << (top->q_o ? 1 : 0)
       << std::endl;
 
   }

--- a/tests/opentitan/module_tests/prim_generic_flop/main.cpp
+++ b/tests/opentitan/module_tests/prim_generic_flop/main.cpp
@@ -37,10 +37,10 @@ int main (int argc, char **argv) {
       top->d_i ^= 1;
 
     std::cout << "time: " << main_time
-      << " rst_ni: " << (top->rst_ni ? 0 : 1)
-      << " clk_i: " << (top->clk_i ? 0 : 1)
-      << " d_i: " << (top->d_i ? 0 : 1)
-      << " q_o: " << (top->q_o ? 0 : 1)
+      << " rst_ni: " << (top->rst_ni ? 1 : 0)
+      << " clk_i: " << (top->clk_i ? 1 : 0)
+      << " d_i: " << (top->d_i ? 1 : 0)
+      << " q_o: " << (top->q_o ? 1 : 0)
       << std::endl;
 
   }

--- a/tests/opentitan/module_tests/prim_generic_flop_2sync/main.cpp
+++ b/tests/opentitan/module_tests/prim_generic_flop_2sync/main.cpp
@@ -37,10 +37,10 @@ int main (int argc, char **argv) {
       top->d_i ^= 1;
 
     std::cout << "time: " << main_time
-      << " rst_ni: " << (top->rst_ni ? 0 : 1)
-      << " clk_i: " << (top->clk_i ? 0 : 1)
-      << " d_i: " << (top->d_i ? 0 : 1)
-      << " q_o: " << (top->q_o ? 0 : 1)
+      << " rst_ni: " << (top->rst_ni ? 1 : 0)
+      << " clk_i: " << (top->clk_i ? 1 : 0)
+      << " d_i: " << (top->d_i ? 1 : 0)
+      << " q_o: " << (top->q_o ? 1 : 0)
       << std::endl;
 
   }


### PR DESCRIPTION
This PR fixes typos in displaying simulation values and introduces a helper target for checking simulation result against vanilla Verilator output.