### PR TITLE
Add tests for prim_arbiter modules

### DIFF
--- a/tests/opentitan/module_tests/prim_arbiter_ppc/Makefile.in
+++ b/tests/opentitan/module_tests/prim_arbiter_ppc/Makefile.in
@@ -1,0 +1,9 @@
+include $(TEST_DIR)/../Makefile.in
+TOP_FILE := \
+    $(OPEN_TITAN_BUILD)/src/lowrisc_prim_all_0.1/rtl/prim_arbiter_ppc.sv
+
+INCLUDE := -I$(OPEN_TITAN_BUILD)/src/lowrisc_prim_assert_0.1/rtl/
+
+TOP_MODULE := prim_arbiter_ppc
+SURELOG_PARAMETERS := -disablefeature=parametersubstitution -PN=5 -PDW=3
+VERILATOR_FLAGS := -Wno-UNOPTFLAT -Wno-ALWCOMBORDER -GN=5 -GDW=3

--- a/tests/opentitan/module_tests/prim_arbiter_ppc/Makefile.in
+++ b/tests/opentitan/module_tests/prim_arbiter_ppc/Makefile.in
@@ -5,5 +5,5 @@ TOP_FILE := \
 INCLUDE := -I$(OPEN_TITAN_BUILD)/src/lowrisc_prim_assert_0.1/rtl/
 
 TOP_MODULE := prim_arbiter_ppc
-SURELOG_PARAMETERS := -disablefeature=parametersubstitution -PN=5 -PDW=3
+SURELOG_FLAGS := -disablefeature=parametersubstitution -PN=5 -PDW=3
 VERILATOR_FLAGS := -Wno-UNOPTFLAT -Wno-ALWCOMBORDER -GN=5 -GDW=3

--- a/tests/opentitan/module_tests/prim_arbiter_ppc/main.cpp
+++ b/tests/opentitan/module_tests/prim_arbiter_ppc/main.cpp
@@ -1,0 +1,66 @@
+#include <iostream>
+#include <verilated_vcd_c.h>
+
+#define VL_DEBUG
+#include "Vprim_arbiter_ppc.h"
+#include "verilated.h"
+
+static vluint64_t main_time = 0;
+
+double
+sc_time_stamp()
+{
+  return main_time;
+}
+
+int main (int argc, char **argv) {
+  Verilated::commandArgs(argc, argv);
+  Vprim_arbiter_ppc *top = new Vprim_arbiter_ppc();
+
+  Verilated::traceEverOn(true);
+  VerilatedVcdC* tfp = new VerilatedVcdC;
+  top->trace(tfp, 99);
+  tfp->open("dump.vcd");
+
+  top->clk_i = 1;
+  top->rst_ni = 0;
+
+  while (!Verilated::gotFinish() && (main_time < 100)) {
+    top->eval();
+    tfp->dump(main_time);
+
+    main_time += 1;
+    top->clk_i ^= 1;
+
+    if (main_time > 10) {
+      top->rst_ni = 1;
+    }
+
+    if (main_time > 20) {
+      top->data_i[0] = 3;
+      top->req_i = 1;
+    }
+
+    if (main_time > 50) {
+      top->ready_i = 1;
+    }
+
+    if (main_time > 70) {
+      top->ready_i = 0;
+    }
+
+    if (main_time > 80) {
+      top->data_i[3] = 5;
+      top->req_i = 8;
+    }
+
+    if (main_time > 90) {
+      top->ready_i = 1;
+    }
+  }
+  top->final();
+  tfp->close();
+    delete top;
+
+  return 0;
+}

--- a/tests/opentitan/module_tests/prim_arbiter_tree/Makefile.in
+++ b/tests/opentitan/module_tests/prim_arbiter_tree/Makefile.in
@@ -5,5 +5,5 @@ TOP_FILE := \
 INCLUDE := -I$(OPEN_TITAN_BUILD)/src/lowrisc_prim_assert_0.1/rtl/
 
 TOP_MODULE := prim_arbiter_tree
-SURELOG_PARAMETERS := -disablefeature=parametersubstitution -PN=5 -PDW=3
+SURELOG_FLAGS := -disablefeature=parametersubstitution -PN=5 -PDW=3
 VERILATOR_FLAGS := -Wno-UNOPTFLAT -Wno-ALWCOMBORDER -GN=5 -GDW=3

--- a/tests/opentitan/module_tests/prim_arbiter_tree/Makefile.in
+++ b/tests/opentitan/module_tests/prim_arbiter_tree/Makefile.in
@@ -1,0 +1,9 @@
+include $(TEST_DIR)/../Makefile.in
+TOP_FILE := \
+    $(OPEN_TITAN_BUILD)/src/lowrisc_prim_all_0.1/rtl/prim_arbiter_tree.sv
+
+INCLUDE := -I$(OPEN_TITAN_BUILD)/src/lowrisc_prim_assert_0.1/rtl/
+
+TOP_MODULE := prim_arbiter_tree
+SURELOG_PARAMETERS := -disablefeature=parametersubstitution -PN=5 -PDW=3
+VERILATOR_FLAGS := -Wno-UNOPTFLAT -Wno-ALWCOMBORDER -GN=5 -GDW=3

--- a/tests/opentitan/module_tests/prim_arbiter_tree/main.cpp
+++ b/tests/opentitan/module_tests/prim_arbiter_tree/main.cpp
@@ -1,0 +1,66 @@
+#include <iostream>
+#include <verilated_vcd_c.h>
+
+#define VL_DEBUG
+#include "Vprim_arbiter_tree.h"
+#include "verilated.h"
+
+static vluint64_t main_time = 0;
+
+double
+sc_time_stamp()
+{
+  return main_time;
+}
+
+int main (int argc, char **argv) {
+  Verilated::commandArgs(argc, argv);
+  Vprim_arbiter_tree *top = new Vprim_arbiter_tree();
+
+  Verilated::traceEverOn(true);
+  VerilatedVcdC* tfp = new VerilatedVcdC;
+  top->trace(tfp, 99);
+  tfp->open("dump.vcd");
+
+  top->clk_i = 1;
+  top->rst_ni = 0;
+
+  while (!Verilated::gotFinish() && (main_time < 100)) {
+    top->eval();
+    tfp->dump(main_time);
+
+    main_time += 1;
+    top->clk_i ^= 1;
+
+    if (main_time > 10) {
+      top->rst_ni = 1;
+    }
+
+    if (main_time > 20) {
+      top->data_i[0] = 3;
+      top->req_i = 1;
+    }
+
+    if (main_time > 50) {
+      top->ready_i = 1;
+    }
+
+    if (main_time > 70) {
+      top->ready_i = 0;
+    }
+
+    if (main_time > 80) {
+      top->data_i[3] = 5;
+      top->req_i = 8;
+    }
+
+    if (main_time > 90) {
+      top->ready_i = 1;
+    }
+  }
+  top->final();
+  tfp->close();
+    delete top;
+
+  return 0;
+}

--- a/tests/opentitan/module_tests/prim_fifo_sync/Makefile.in
+++ b/tests/opentitan/module_tests/prim_fifo_sync/Makefile.in
@@ -1,0 +1,11 @@
+include $(TEST_DIR)/../Makefile.in
+TOP_FILE := \
+    $(OPEN_TITAN_BUILD)/src/lowrisc_prim_abstract_prim_pkg_0.1/prim_pkg.sv \
+    $(OPEN_TITAN_BUILD)/src/lowrisc_prim_util_0.1/rtl/prim_util_pkg.sv \
+    $(OPEN_TITAN_BUILD)/src/lowrisc_prim_all_0.1/rtl/prim_fifo_sync.sv
+
+INCLUDE := -I$(OPEN_TITAN_BUILD)/src/lowrisc_prim_assert_0.1/rtl/ -I$(OPEN_TITAN_BUILD)/src/lowrisc_prim_util_0.1/rtl/
+
+TOP_MODULE := prim_fifo_sync
+SURELOG_FLAGS := --disable-feature=parametersubstitution -PWidth=8 -PPass=1\'b1 -PDepth=2
+VERILATOR_FLAGS := -GWidth=8 -GPass=1\'b1 -GDepth=2

--- a/tests/opentitan/module_tests/prim_fifo_sync/main.cpp
+++ b/tests/opentitan/module_tests/prim_fifo_sync/main.cpp
@@ -1,0 +1,59 @@
+#include <iostream>
+#include <verilated_vcd_c.h>
+
+#define VL_DEBUG
+#include "Vprim_fifo_sync.h"
+#include "verilated.h"
+
+static vluint64_t main_time = 0;
+
+double
+sc_time_stamp()
+{
+  return main_time;
+}
+
+int main (int argc, char **argv) {
+  Verilated::commandArgs(argc, argv);
+  Vprim_fifo_sync *top = new Vprim_fifo_sync();
+
+  Verilated::traceEverOn(true);
+  VerilatedVcdC* tfp = new VerilatedVcdC;
+  top->trace(tfp, 99);
+  tfp->open("dump.vcd");
+
+  top->clk_i = 1;
+  top->rst_ni = 0;
+  top->clr_i = 0;
+  while (!Verilated::gotFinish() && (main_time < 100)) {
+    top->eval();
+    tfp->dump(main_time);
+
+    main_time += 1;
+    top->clk_i ^= 1;
+
+    if (main_time > 10) {
+      top->rst_ni = 1;
+    }
+
+    if (main_time > 20) {
+      top->wdata_i ^= 1;
+      if (!(main_time % 5))
+        top->wvalid_i ^= 1;
+    }
+
+    if (main_time > 50) {
+      top->rready_i = 1;
+    }
+
+    if (main_time > 70) {
+      top->clr_i = 1;
+    }
+
+  }
+  top->final();
+  tfp->close();
+    delete top;
+
+  return 0;
+}

--- a/tests/opentitan/module_tests/prim_sram_arbiter/Makefile.in
+++ b/tests/opentitan/module_tests/prim_sram_arbiter/Makefile.in
@@ -1,0 +1,15 @@
+include $(TEST_DIR)/../Makefile.in
+TOP_FILE := \
+    $(OPEN_TITAN_BUILD)/src/lowrisc_prim_abstract_prim_pkg_0.1/prim_pkg.sv \
+    $(OPEN_TITAN_BUILD)/src/lowrisc_prim_util_0.1/rtl/prim_util_pkg.sv \
+    $(OPEN_TITAN_BUILD)/src/lowrisc_prim_all_0.1/rtl/prim_fifo_sync.sv \
+    $(OPEN_TITAN_BUILD)/src/lowrisc_prim_all_0.1/rtl/prim_arbiter_tree.sv \
+    $(OPEN_TITAN_BUILD)/src/lowrisc_prim_all_0.1/rtl/prim_arbiter_ppc.sv \
+    $(OPEN_TITAN_BUILD)/src/lowrisc_prim_all_0.1/rtl/prim_sram_arbiter.sv
+
+INCLUDE := -I$(OPEN_TITAN_BUILD)/src/lowrisc_prim_assert_0.1/rtl/
+
+TOP_MODULE := prim_sram_arbiter
+# Parameters set in spi_device_pkg.sv, spi_device.sv
+SURELOG_FLAGS := -PN=2 -PSramAw=10 -PSramDw=32
+VERILATOR_FLAGS := -Wno-ALWCOMBORDER -GN=2 -GSramAw=10 -GSramDw=32

--- a/tests/opentitan/module_tests/prim_sram_arbiter/main.cpp
+++ b/tests/opentitan/module_tests/prim_sram_arbiter/main.cpp
@@ -1,0 +1,66 @@
+#include <iostream>
+#include <verilated_vcd_c.h>
+
+#define VL_DEBUG
+#include "Vprim_sram_arbiter.h"
+#include "verilated.h"
+
+static vluint64_t main_time = 0;
+
+double
+sc_time_stamp()
+{
+  return main_time;
+}
+
+int main (int argc, char **argv) {
+  Verilated::commandArgs(argc, argv);
+  Vprim_sram_arbiter *top = new Vprim_sram_arbiter();
+
+  Verilated::traceEverOn(true);
+  VerilatedVcdC* tfp = new VerilatedVcdC;
+  top->trace(tfp, 99);
+  tfp->open("dump.vcd");
+
+  top->clk_i = 1;
+  top->rst_ni = 0;
+
+  while (!Verilated::gotFinish() && (main_time < 100)) {
+    top->eval();
+    tfp->dump(main_time);
+
+    main_time += 1;
+    top->clk_i ^= 1;
+
+    if (main_time > 10) {
+      top->rst_ni = 1;
+    }
+
+    if (main_time > 20) {
+      top->req_wdata_i[0] = 3;
+      top->req_i = 1;
+    }
+
+    if (main_time > 50) {
+      top->req_write_i[0] = 1;
+    }
+
+    if (main_time > 70) {
+      top->req_write_i[0] = 0;
+    }
+
+    if (main_time > 80) {
+      top->req_wdata_i[3] = 5;
+      top->req_i = 8;
+    }
+
+    if (main_time > 90) {
+      top->req_write_i[3] = 1;
+    }
+  }
+  top->final();
+  tfp->close();
+    delete top;
+
+  return 0;
+}


### PR DESCRIPTION
This PR adds individual module tests for:
* prim_fifo_sync (https://github.com/alainmarcel/uhdm-integration/issues/256)
* prim_arbiter_tree (https://github.com/alainmarcel/uhdm-integration/issues/259)
* prim_arbiter_ppc (https://github.com/alainmarcel/uhdm-integration/issues/258)
* prim_sram_arbiter (https://github.com/alainmarcel/uhdm-integration/issues/260)