### PR TITLE
Change name of top module to the name of file

### DIFF
--- a/tests/ibex/module_tests/register_file/Makefile.in
+++ b/tests/ibex/module_tests/register_file/Makefile.in
@@ -1,4 +1,4 @@
 include $(TEST_DIR)/../Makefile.in
 TOP_FILE := $(IBEX_BUILD)/src/lowrisc_ibex_ibex_pkg_0.1/rtl/ibex_pkg.sv \
     $(IBEX_BUILD)/src/lowrisc_ibex_ibex_core_0.1/rtl/ibex_register_file_ff.sv
-TOP_MODULE := ibex_register_file
+TOP_MODULE := ibex_register_file_ff

--- a/tests/ibex/module_tests/register_file/main.cpp
+++ b/tests/ibex/module_tests/register_file/main.cpp
@@ -1,6 +1,6 @@
 #include <verilated.h>
 #include <verilated_vcd_c.h>
-#include "Vibex_register_file.h"
+#include "Vibex_register_file_ff.h"
 
 vluint64_t main_time = 0;
 
@@ -9,7 +9,7 @@ int main(int argc, char* argv[])
   Verilated::traceEverOn(true);
   VerilatedVcdC* tfp = new VerilatedVcdC;
 
-  Vibex_register_file* top = new Vibex_register_file;
+  Vibex_register_file_ff* top = new Vibex_register_file_ff;
   top->trace(tfp, 99);
   tfp->open("dump.vcd");
 


### PR DESCRIPTION
An error occurred in https://github.com/antmicro/verilator/runs/2287938592?check_suite_focus=true#step:7:6753, because `TOP_MODULE` variable was different from module name. 