### PR TITLE
Fix else-if tests in Yosys

### DIFF
--- a/tests/conditional_if/if.sv
+++ b/tests/conditional_if/if.sv
@@ -3,9 +3,9 @@
 :description: A module testing if statement
 :tags: 12.4
 */
-module top (b);
+module top ();
 	wire a = 1;
-	output reg b = 0;
+	reg b = 0;
 	always @* begin
 		if(a) b = 1;
 	end

--- a/tests/conditional_if/yosys_script
+++ b/tests/conditional_if/yosys_script
@@ -1,6 +1,27 @@
 read_uhdm -debug top.uhdm
 write_json
-prep -top \top
-write_verilog
+hierarchy -check -top \top
+proc_clean
+proc_rmdead
+proc_prune
+proc_init
+proc_arst
+proc_mux
+proc_dff
+proc_clean
+proc_dlatch
+opt
+
+opt_expr -keepdc
+opt_clean
+check
+opt -noff -keepdc
+wreduce -keepdc
+opt_clean
+memory_collect
+opt -noff -keepdc -fast
+stat
+check
+
 write_verilog yosys.sv
 sim -rstlen 10 -vcd dump.vcd

--- a/tests/conditional_if_else/if_else.sv
+++ b/tests/conditional_if_else/if_else.sv
@@ -3,9 +3,9 @@
 :description: A module testing if-else statement
 :tags: 12.4
 */
-module top (b);
+module top ();
 	wire a = 1;
-	output reg b = 0;
+	reg b = 0;
 	always @* begin
 		if(a) b = 1;
 		else b = 0;

--- a/tests/conditional_if_else/yosys_script
+++ b/tests/conditional_if_else/yosys_script
@@ -1,6 +1,27 @@
 read_uhdm -debug top.uhdm
 write_json
-prep -top \top
-write_verilog
+hierarchy -check -top \top
+proc_clean
+proc_rmdead
+proc_prune
+proc_init
+proc_arst
+proc_mux
+proc_dff
+proc_clean
+proc_dlatch
+opt
+
+opt_expr -keepdc
+opt_clean
+check
+opt -noff -keepdc
+wreduce -keepdc
+opt_clean
+memory_collect
+opt -noff -keepdc -fast
+stat
+check
+
 write_verilog yosys.sv
 sim -rstlen 10 -vcd dump.vcd


### PR DESCRIPTION
This PR is returning if-else tests to original state as in sv-tests: 
* https://github.com/SymbiFlow/sv-tests/blob/master/tests/chapter-12/12.4--if.sv
* https://github.com/SymbiFlow/sv-tests/blob/master/tests/chapter-12/12.4--if_else.sv

It also changes the Yosys scripts in a way that will prevent optimizing out unused `b` variables