### PR TITLE
Add clean-build step to verilator/test-ast

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -124,7 +124,7 @@ uhdm/verilator/ast-xml: surelog/parse
 			--debugi 6 \
 			--exe $(MAIN_FILE) --xml-only)
 
-verilator/test-ast:
+verilator/test-ast: clean-build
 	mkdir -p $(root_dir)/dumps
 	(cd $(root_dir)/build && \
 		$(VERILATOR_BIN) \


### PR DESCRIPTION
I added that step to make possible to rerun test with original verilator. 