### PR TITLE
Add definitions of functions

### DIFF
--- a/tests/DpiChandle/Makefile.in
+++ b/tests/DpiChandle/Makefile.in
@@ -1,2 +1,3 @@
 TOP_FILE := $(TEST_DIR)/top.sv
 TOP_MODULE := top
+VERILATOR_FLAGS := $(TEST_DIR)/functions.cpp

--- a/tests/DpiChandle/functions.cpp
+++ b/tests/DpiChandle/functions.cpp
@@ -1,0 +1,8 @@
+extern "C" void* test_output()
+{
+  return 0;
+}
+
+extern "C" void test_input(const void* in)
+{
+}

--- a/tests/DpiChandle/main.cpp
+++ b/tests/DpiChandle/main.cpp
@@ -26,11 +26,15 @@ int main (int argc, char **argv) {
     top->eval();
     tfp->dump(main_time);
 
+    std::cout << "time: " << main_time
+              << " a: " << (top->a ? 1 : 0)
+      << std::endl;
+
     main_time += 1;
   }
   top->final();
   tfp->close();
-    delete top;
+  delete top;
 
   return 0;
 }

--- a/tests/DpiChandle/top.sv
+++ b/tests/DpiChandle/top.sv
@@ -1,8 +1,17 @@
-module top;
+module top(output reg a);
    import "DPI-C" function
      chandle test_output();
 
    import "DPI-C" function
      void test_input(input chandle in);
 
+initial begin
+   chandle ch = test_output();
+   test_input(ch);
+
+   if (ch == 0)
+     assign a = 0;
+   else
+     assign a = 1;
+   end
 endmodule


### PR DESCRIPTION
I added the definitions of functions.
Before in case of original verilator linker was throwing errors, because it was unable to find them and uhdm-verilator was passing this test, because it was omitting DPI-C imported functions.