### PR TITLE
Add EnumConcat test

### DIFF
--- a/tests/EnumConcat/Makefile.in
+++ b/tests/EnumConcat/Makefile.in
@@ -1,0 +1,2 @@
+TOP_FILE := $(TEST_DIR)/dut.v
+TOP_MODULE := dut

--- a/tests/EnumConcat/dut.v
+++ b/tests/EnumConcat/dut.v
@@ -1,0 +1,19 @@
+package pkg;
+	typedef enum logic [3:0] {
+		PRIV_LVL_M = 4'b11
+		} priv_lvl_e;
+endpackage
+
+module dut(a0);
+	input a0;
+
+	import pkg::*;
+
+	logic [3:0] c [4];
+
+	for (genvar i = 0; i < 4; i++) begin
+		always @(posedge a0) begin
+			c[i] = {PRIV_LVL_M};
+		end
+	end
+endmodule

--- a/tests/EnumConcat/main.cpp
+++ b/tests/EnumConcat/main.cpp
@@ -1,0 +1,44 @@
+#include <iostream>
+#include <verilated_vcd_c.h>
+
+#define VL_DEBUG
+#include "Vdut.h"
+#include "verilated.h"
+
+static vluint64_t main_time = 0;
+
+double
+sc_time_stamp()
+{
+  return main_time;
+}
+
+int main (int argc, char **argv) {
+  Verilated::commandArgs(argc, argv);
+  Vdut *top = new Vdut();
+
+  Verilated::traceEverOn(true);
+  VerilatedVcdC* tfp = new VerilatedVcdC;
+  top->trace(tfp, 99);
+  tfp->open("dump.vcd");
+
+  top->a0 = 0;
+  while (!Verilated::gotFinish() && (main_time < 100)) {
+    top->eval();
+    tfp->dump(main_time);
+
+    main_time += 1;
+
+    if (!(main_time % 5)) {
+      top->a0 ^=1;
+    }
+    std::cout << "time: " << main_time
+      << " a0: " << (top->a0 ? 1:0)
+      << std::endl;
+  }
+  top->final();
+  tfp->close();
+    delete top;
+
+  return 0;
+}

--- a/tests/EnumConcat/yosys_script
+++ b/tests/EnumConcat/yosys_script
@@ -1,0 +1,6 @@
+read_uhdm -debug dut.uhdm
+write_json
+prep -top \dut
+write_verilog
+write_verilog yosys.sv
+sim -clock a0 -rstlen 10 -vcd dump.vcd

--- a/tests/ibex/module_tests/ram_2p/Makefile.in
+++ b/tests/ibex/module_tests/ram_2p/Makefile.in
@@ -1,5 +1,6 @@
 include $(TEST_DIR)/../Makefile.in
 TOP_FILE := $(IBEX_BUILD)/../lowrisc_ibex_ibex_simple_system_0/src/lowrisc_ibex_ibex_pkg_0.1/rtl/ibex_pkg.sv \
+    $(IBEX_BUILD)/../lowrisc_ibex_ibex_simple_system_0/src/lowrisc_prim_ram_2p_pkg_0/rtl/prim_ram_2p_pkg.sv \
     $(IBEX_BUILD)/../lowrisc_ibex_ibex_simple_system_0/src/lowrisc_ibex_sim_shared_0/rtl/ram_2p.sv \
     $(IBEX_BUILD)/../lowrisc_ibex_ibex_simple_system_0/src/lowrisc_prim_abstract_ram_2p_0/prim_ram_2p.sv \
     $(IBEX_BUILD)/../lowrisc_ibex_ibex_simple_system_0/src/lowrisc_prim_generic_ram_2p_0/rtl/prim_generic_ram_2p.sv


### PR DESCRIPTION
This PR adds a test that checks enum constant handling due to changes in Surelog. It also updates the Ibex module ram_2p test that was missing a package.