### PR TITLE
Add test where memory is part of port

### DIFF
--- a/tests/MemoryPort/Makefile.in
+++ b/tests/MemoryPort/Makefile.in
@@ -1,0 +1,2 @@
+TOP_FILE := $(TEST_DIR)/top.sv
+TOP_MODULE := top

--- a/tests/MemoryPort/main.cpp
+++ b/tests/MemoryPort/main.cpp
@@ -1,0 +1,37 @@
+#include <iostream>
+#include <verilated_vcd_c.h>
+
+#define VL_DEBUG
+#include "Vtop.h"
+#include "verilated.h"
+
+static vluint64_t main_time = 0;
+
+double
+sc_time_stamp()
+{
+  return main_time;
+}
+
+int main (int argc, char **argv) {
+  Verilated::commandArgs(argc, argv);
+  Vtop *top = new Vtop();
+
+  Verilated::traceEverOn(true);
+  VerilatedVcdC* tfp = new VerilatedVcdC;
+  top->trace(tfp, 99);
+  tfp->open("dump.vcd");
+
+  while (!Verilated::gotFinish() && (main_time < 100)) {
+    top->eval();
+    tfp->dump(main_time);
+
+    main_time += 1;
+
+  }
+  top->final();
+  tfp->close();
+    delete top;
+
+  return 0;
+}

--- a/tests/MemoryPort/top.sv
+++ b/tests/MemoryPort/top.sv
@@ -1,0 +1,10 @@
+module top(output logic [31:0] a [10]);
+  logic [31:0] b;
+  for(genvar i = 0; i < 10; i++) begin
+     assign a[i] = i;
+  end
+  assign b = a[9]; //b should == 9
+  always_comb begin
+    assert(b == 32'b00000000000000000000000000001001);
+  end
+endmodule

--- a/tests/MemoryPort/yosys_script
+++ b/tests/MemoryPort/yosys_script
@@ -1,0 +1,6 @@
+read_uhdm -debug top.uhdm
+write_json
+prep -top \top
+write_verilog
+write_verilog yosys.sv
+sim -rstlen 10 -vcd dump.vcd


### PR DESCRIPTION
This tests check wire that has packed and unpacked ranges and it is part of the port declaration.

Yosys treats this kind of wires differently from one that is inside module, as it can't replace memory declaration with list of registers.
 
Signed-off-by: Kamil Rakoczy <krakoczy@antmicro.com>