### PR TITLE
Do not clean tool images in make clean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,6 @@ clean-build:
 	mkdir -p $(root_dir)/build
 
 clean:: clean-build
-	rm -rf $(root_dir)/image
 
 # ------------ Other targets ------------
 


### PR DESCRIPTION
Tools are now not build from submodules, but independently from other
repos. Do not attempt to clean them here, remove only actual test
build files.