### PR TITLE
Add test of prim_packer.sv module

### DIFF
--- a/tests/opentitan/module_tests/prim_packer/Makefile.in
+++ b/tests/opentitan/module_tests/prim_packer/Makefile.in
@@ -1,0 +1,10 @@
+include $(TEST_DIR)/../Makefile.in
+TOP_FILE := \
+    $(OPEN_TITAN_BUILD)/src/lowrisc_prim_all_0.1/rtl/prim_packer.sv
+
+INCLUDE := -I$(OPEN_TITAN_BUILD)/src/lowrisc_prim_assert_0.1/rtl/
+
+TOP_MODULE := prim_packer
+
+VERILATOR_FLAGS := -Wno-Width -GInW=64 -GOutW=64
+SURELOG_FLAGS := -PInW=64 -POutW=64

--- a/tests/opentitan/module_tests/prim_packer/main.cpp
+++ b/tests/opentitan/module_tests/prim_packer/main.cpp
@@ -1,0 +1,46 @@
+#include <iostream>
+#include <verilated_vcd_c.h>
+
+#define VL_DEBUG
+#include "Vprim_packer.h"
+#include "verilated.h"
+
+static vluint64_t main_time = 0;
+
+double
+sc_time_stamp()
+{
+  return main_time;
+}
+
+int main (int argc, char **argv) {
+  Verilated::commandArgs(argc, argv);
+  Vprim_packer *top = new Vprim_packer();
+
+  Verilated::traceEverOn(true);
+  VerilatedVcdC* tfp = new VerilatedVcdC;
+  top->trace(tfp, 99);
+  tfp->open("dump.vcd");
+
+  top->clk_i = 0;
+  top->rst_ni = 0;
+  while (!Verilated::gotFinish() && (main_time < 100)) {
+    top->eval();
+    tfp->dump(main_time);
+
+    std::cout << "time: " << main_time
+      << " clk_i: " << (top->clk_i ? 1 : 0)
+      << " rst_ni: " << (top->rst_ni ? 1 : 0)
+      << " ready_o: " << (top->ready_o ? 1 : 0)
+      << std::endl;
+
+    main_time += 1;
+    top->clk_i = main_time & 1;
+    top->rst_ni = main_time & 2;
+  }
+  top->final();
+  tfp->close();
+  delete top;
+
+  return 0;
+}


### PR DESCRIPTION
I created this test during investigation of https://github.com/alainmarcel/uhdm-integration/issues/333.
I set the parameters to the values that are used when this module is invoked in `kmac_msgfifo.sv` module. 
I used also `-WnoWidth` flag, because it was giving warnings about WIDTH in both uhdm-verilator and the original verilator. 