### PR TITLE
Add test of prim_prince module

### DIFF
--- a/tests/opentitan/module_tests/prim_prince/Makefile.in
+++ b/tests/opentitan/module_tests/prim_prince/Makefile.in
@@ -1,0 +1,10 @@
+include $(TEST_DIR)/../Makefile.in
+TOP_FILE := \
+   $(OPEN_TITAN_BUILD)/src/lowrisc_prim_all_0.1/rtl/prim_cipher_pkg.sv \
+   $(OPEN_TITAN_BUILD)/src/lowrisc_prim_all_0.1/rtl/prim_prince.sv
+
+INCLUDE := -I$(OPEN_TITAN_BUILD)/src/lowrisc_prim_assert_0.1/rtl/
+
+TOP_MODULE := prim_prince
+
+VERILATOR_FLAGS := $(TEST_DIR)/prim_prince.vlt

--- a/tests/opentitan/module_tests/prim_prince/main.cpp
+++ b/tests/opentitan/module_tests/prim_prince/main.cpp
@@ -39,7 +39,7 @@ int main (int argc, char **argv) {
               << " rst_ni: " << (top->rst_ni ? 1 : 0)
               << " valid_i: " << (top->valid_i ? 1 : 0)
               << " data_i: " << top->data_i
-              << " key_i: " << top->key_i
+              << " key_i: " << top->key_i[0]
               << " dec_i: " << (top->dec_i ? 1 : 0)
               << " valid_o: " << (top->valid_o ? 1 : 0)
               << " data_o: " << top->data_o

--- a/tests/opentitan/module_tests/prim_prince/main.cpp
+++ b/tests/opentitan/module_tests/prim_prince/main.cpp
@@ -1,0 +1,60 @@
+#include <iostream>
+#include <verilated_vcd_c.h>
+
+#define VL_DEBUG
+#include "Vprim_prince.h"
+#include "verilated.h"
+
+static vluint64_t main_time = 0;
+
+double
+sc_time_stamp()
+{
+  return main_time;
+}
+
+int main (int argc, char **argv) {
+  Verilated::commandArgs(argc, argv);
+  Vprim_prince *top = new Vprim_prince();
+
+  Verilated::traceEverOn(true);
+  VerilatedVcdC* tfp = new VerilatedVcdC;
+  top->trace(tfp, 99);
+  tfp->open("dump.vcd");
+
+  top->clk_i = 0;
+  top->rst_ni = 0;
+  top->valid_i = 0;
+  top->dec_i = 0;
+
+  top->data_i = 0xABCD;
+  top->key_i[0] = 0x1234;
+  
+  while (!Verilated::gotFinish() && (main_time < 100)) {
+    top->eval();
+    tfp->dump(main_time);
+
+    std::cout << "time: " << main_time
+              << " clk_i: " << (top->clk_i ? 1 : 0)
+              << " rst_ni: " << (top->rst_ni ? 1 : 0)
+              << " valid_i: " << (top->valid_i ? 1 : 0)
+              << " data_i: " << top->data_i
+              << " key_i: " << top->key_i
+              << " dec_i: " << (top->dec_i ? 1 : 0)
+              << " valid_o: " << (top->valid_o ? 1 : 0)
+              << " data_o: " << top->data_o
+              << std::endl;
+
+    main_time += 1;
+
+    top->clk_i = main_time & 1;
+    top->rst_ni = main_time & 2;
+    top->valid_i = main_time & 3;
+    top->dec_i = main_time & 4;
+  }
+  top->final();
+  tfp->close();
+  delete top;
+
+  return 0;
+}

--- a/tests/opentitan/module_tests/prim_prince/prim_prince.vlt
+++ b/tests/opentitan/module_tests/prim_prince/prim_prince.vlt
@@ -1,0 +1,3 @@
+`verilator_config
+
+lint_off -rule UNOPTFLAT -file "*" -match "Signal unoptimizable: Feedback to clock or circular logic: 'prim_prince.*'"

--- a/tests/xor_assignment/Makefile.in
+++ b/tests/xor_assignment/Makefile.in
@@ -1,0 +1,2 @@
+TOP_FILE := $(TEST_DIR)/top.sv
+TOP_MODULE := top

--- a/tests/xor_assignment/main.cpp
+++ b/tests/xor_assignment/main.cpp
@@ -1,0 +1,40 @@
+#include <iostream>
+#include <verilated_vcd_c.h>
+
+#define VL_DEBUG
+#include "Vtop.h"
+#include "verilated.h"
+
+static vluint64_t main_time = 0;
+
+double
+sc_time_stamp()
+{
+  return main_time;
+}
+
+int main (int argc, char **argv) {
+  Verilated::commandArgs(argc, argv);
+  Vtop *top = new Vtop();
+
+  Verilated::traceEverOn(true);
+  VerilatedVcdC* tfp = new VerilatedVcdC;
+  top->trace(tfp, 99);
+  tfp->open("dump.vcd");
+
+   while (!Verilated::gotFinish() && (main_time < 100)) {
+    top->eval();
+    tfp->dump(main_time);
+
+    main_time += 1;
+
+    std::cout << "time: " << main_time
+      << " a: " << (top->a ? 1 : 0)
+      << std::endl;
+  }
+  top->final();
+  tfp->close();
+  delete top;
+
+  return 0;
+}

--- a/tests/xor_assignment/top.sv
+++ b/tests/xor_assignment/top.sv
@@ -1,0 +1,6 @@
+module top(output logic a);
+   initial begin
+      a  = 1; 
+      a ^= 0;
+   end
+endmodule

--- a/tests/xor_assignment/yosys_script
+++ b/tests/xor_assignment/yosys_script
@@ -1,0 +1,5 @@
+read_uhdm -debug top.uhdm
+hierarchy
+proc
+opt
+sat -verify -seq 1 -tempinduct -prove-asserts -show-all


### PR DESCRIPTION
I created the test of `prim_prince.sv` module.
I used lint off rule, because it was giving UNOPTFLAT warnings when was tested by original verilator.
 